### PR TITLE
feat: add CQL import from library to measure CQL tab (#PAT-056)

### DIFF
--- a/frontend/src/components/measure/ImportCqlFromLibraryDialog.tsx
+++ b/frontend/src/components/measure/ImportCqlFromLibraryDialog.tsx
@@ -1,0 +1,145 @@
+import { useState, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  List,
+  ListItemButton,
+  ListItemText,
+  Typography,
+  CircularProgress,
+  Box,
+  Chip,
+  InputAdornment,
+} from '@mui/material'
+import { Search as SearchIcon } from '@mui/icons-material'
+import { useQuery } from '@tanstack/react-query'
+import { cqlApi } from '../../api'
+import type { CqlLibrary } from '../../types'
+import { SEARCH_DEBOUNCE_GENERAL_MS } from '../../constants/timing'
+
+interface ImportCqlFromLibraryDialogProps {
+  open: boolean
+  onClose: () => void
+  onImport: (cqlContent: string) => void
+  hasExistingContent: boolean
+}
+
+export default function ImportCqlFromLibraryDialog({
+  open,
+  onClose,
+  onImport,
+  hasExistingContent,
+}: ImportCqlFromLibraryDialogProps) {
+  const { t } = useTranslation('measures')
+  const [search, setSearch] = useState('')
+  const [selected, setSelected] = useState<CqlLibrary | null>(null)
+  const [debouncedSearch, setDebouncedSearch] = useState('')
+
+  // Debounce search input
+  useState(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search), SEARCH_DEBOUNCE_GENERAL_MS)
+    return () => clearTimeout(timer)
+  })
+
+  const { data: libraries, isLoading } = useQuery({
+    queryKey: ['cql-libraries', debouncedSearch],
+    queryFn: () => cqlApi.getLibraries(debouncedSearch || undefined),
+    enabled: open,
+  })
+
+  const filteredLibraries = useMemo(() => {
+    if (!libraries) return []
+    if (!search) return libraries
+    const lower = search.toLowerCase()
+    return libraries.filter(
+      (lib) =>
+        lib.name.toLowerCase().includes(lower) ||
+        (lib.description && lib.description.toLowerCase().includes(lower))
+    )
+  }, [libraries, search])
+
+  const handleImport = () => {
+    if (!selected) return
+    if (hasExistingContent) {
+      if (!window.confirm(t('cql.importDialog.confirmOverwrite'))) return
+    }
+    onImport(selected.cqlContent)
+    handleClose()
+  }
+
+  const handleClose = () => {
+    setSearch('')
+    setSelected(null)
+    onClose()
+  }
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>{t('cql.importDialog.title')}</DialogTitle>
+      <DialogContent>
+        <TextField
+          fullWidth
+          size="small"
+          placeholder={t('cql.importDialog.search')}
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          sx={{ mb: 1, mt: 1 }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon fontSize="small" />
+              </InputAdornment>
+            ),
+          }}
+        />
+        {isLoading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress size={32} />
+          </Box>
+        ) : filteredLibraries.length === 0 ? (
+          <Typography variant="body2" color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
+            {t('cql.importDialog.noLibraries')}
+          </Typography>
+        ) : (
+          <List sx={{ maxHeight: 350, overflow: 'auto' }}>
+            {filteredLibraries.map((lib) => (
+              <ListItemButton
+                key={lib.id}
+                selected={selected?.id === lib.id}
+                onClick={() => setSelected(lib)}
+              >
+                <ListItemText
+                  primary={
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <Typography variant="body2" fontWeight="medium">
+                        {lib.name}
+                      </Typography>
+                      <Chip
+                        label={t('cql.importDialog.version', { version: lib.version })}
+                        size="small"
+                        variant="outlined"
+                        sx={{ height: 20, fontSize: '0.7rem' }}
+                      />
+                    </Box>
+                  }
+                  secondary={lib.description || undefined}
+                />
+              </ListItemButton>
+            ))}
+          </List>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>{t('cql.importDialog.cancel')}</Button>
+        <Button variant="contained" disabled={!selected} onClick={handleImport}>
+          {t('cql.importDialog.import')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/measure/MeasureCqlTab.tsx
+++ b/frontend/src/components/measure/MeasureCqlTab.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { extractApiError } from '../../utils/errorUtils'
 import { Box, Stack, Button, CircularProgress, Alert, Chip } from '@mui/material'
-import { Translate as TranslateIcon, Save as SaveIcon } from '@mui/icons-material'
+import { Translate as TranslateIcon, Save as SaveIcon, FileUpload as ImportIcon } from '@mui/icons-material'
 import GradientButton from '../common/GradientButton'
 import { useSelector, useDispatch } from 'react-redux'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
@@ -12,6 +12,7 @@ import CqlEditor from '../editor/CqlEditor'
 import type { CqlEditorHandle } from '../editor/CqlEditor'
 import { measureApi, cqlApi } from '../../api'
 import { useUnsavedChangesGuard } from '../../hooks/useUnsavedChangesGuard'
+import ImportCqlFromLibraryDialog from './ImportCqlFromLibraryDialog'
 import type { MeasureDefinition } from '../../types'
 import { AUTOSAVE_DEBOUNCE_MS } from '../../constants/timing'
 
@@ -30,6 +31,7 @@ export default function MeasureCqlTab({ measure, onMeasureUpdate, readOnly }: Me
   const queryClient = useQueryClient()
   const autosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [restoredDraft, setRestoredDraft] = useState(false)
+  const [importDialogOpen, setImportDialogOpen] = useState(false)
   const cqlEditorRef = useRef<CqlEditorHandle>(null)
   // Local mirror of editor content — updated via onContentChanged callback
   const [localContent, setLocalContent] = useState('')
@@ -111,6 +113,11 @@ export default function MeasureCqlTab({ measure, onMeasureUpdate, readOnly }: Me
     },
   })
 
+  const handleImportCql = useCallback((cqlContent: string) => {
+    dispatch(setCqlContent(cqlContent))
+    setLocalContent(cqlContent)
+  }, [dispatch])
+
   const isDirty = localContent !== (measure.cqlContent || '')
   useUnsavedChangesGuard(isDirty)
 
@@ -143,6 +150,15 @@ export default function MeasureCqlTab({ measure, onMeasureUpdate, readOnly }: Me
         >
           {saveMutation.isPending ? t('cql.saving') : t('cql.saveCql')}
         </GradientButton>
+        <Button
+          size="small"
+          variant="outlined"
+          startIcon={<ImportIcon />}
+          disabled={readOnly}
+          onClick={() => setImportDialogOpen(true)}
+        >
+          {t('cql.importFromLibrary')}
+        </Button>
         {isDirty && (
           <Alert severity="info" sx={{ py: 0, px: 1, fontSize: '0.75rem' }}>
             {t('cql.unsavedChanges')}
@@ -179,6 +195,13 @@ export default function MeasureCqlTab({ measure, onMeasureUpdate, readOnly }: Me
       <Box sx={{ flex: 1, minHeight: 0 }}>
         <CqlEditor ref={cqlEditorRef} height="100%" readOnly={readOnly} onContentChanged={handleContentChanged} />
       </Box>
+
+      <ImportCqlFromLibraryDialog
+        open={importDialogOpen}
+        onClose={() => setImportDialogOpen(false)}
+        onImport={handleImportCql}
+        hasExistingContent={!!localContent.trim()}
+      />
     </Box>
   )
 }

--- a/frontend/src/locales/en/measures.json
+++ b/frontend/src/locales/en/measures.json
@@ -235,6 +235,7 @@
     "translate": "Translate",
     "saving": "Saving...",
     "saveCql": "Save CQL",
+    "importFromLibrary": "Import from Library",
     "unsavedChanges": "Unsaved changes",
     "errorCount": "{{count}} errors",
     "errorCount_one": "{{count}} error",
@@ -242,7 +243,16 @@
     "warningCount_one": "{{count}} warning",
     "discardDraft": "Discard Draft",
     "draftRestored": "Restored unsaved draft from a previous session.",
-    "translationFailed": "Translation failed: {{error}}"
+    "translationFailed": "Translation failed: {{error}}",
+    "importDialog": {
+      "title": "Import CQL from Library",
+      "search": "Search libraries...",
+      "noLibraries": "No CQL libraries found.",
+      "import": "Import",
+      "cancel": "Cancel",
+      "confirmOverwrite": "This will replace the current CQL content. Continue?",
+      "version": "v{{version}}"
+    }
   },
   "populationCriteria": {
     "title": "Population Criteria",

--- a/frontend/src/locales/zh-TW/measures.json
+++ b/frontend/src/locales/zh-TW/measures.json
@@ -235,6 +235,7 @@
     "translate": "翻譯",
     "saving": "儲存中...",
     "saveCql": "儲存 CQL",
+    "importFromLibrary": "從程式庫匯入",
     "unsavedChanges": "未儲存的變更",
     "errorCount": "{{count}} 個錯誤",
     "errorCount_one": "{{count}} 個錯誤",
@@ -242,7 +243,16 @@
     "warningCount_one": "{{count}} 個警告",
     "discardDraft": "捨棄草稿",
     "draftRestored": "已恢復上次未儲存的草稿。",
-    "translationFailed": "翻譯失敗：{{error}}"
+    "translationFailed": "翻譯失敗：{{error}}",
+    "importDialog": {
+      "title": "從程式庫匯入 CQL",
+      "search": "搜尋程式庫...",
+      "noLibraries": "找不到 CQL 程式庫。",
+      "import": "匯入",
+      "cancel": "取消",
+      "confirmOverwrite": "這將取代目前的 CQL 內容，確定要繼續嗎？",
+      "version": "v{{version}}"
+    }
   },
   "populationCriteria": {
     "title": "族群條件",


### PR DESCRIPTION
## 變更說明

品質指標 CQL Tab 新增「從程式庫匯入」功能，讓使用者可以從已儲存的 CQL 程式庫中選擇並載入 CQL 內容到指標編輯器。

## 變更類型

- [x] 新功能 (feat)

## 關聯 Issue

Closes #81

## 測試紀錄

- [ ] 後端測試通過 (`mvn test`)
- [ ] 前端測試通過 (`npm test`)
- [x] 型別檢查通過 (`npx tsc --noEmit`)

**測試摘要：**
- TypeScript 型別檢查通過
- 新元件 ImportCqlFromLibraryDialog：搜尋 + 選擇 + 確認覆蓋
- 使用現有 `/api/cql/libraries` API，無後端變更

## 風險評估

| 項目 | 說明 |
|------|------|
| 風險等級 | 低 |
| 影響範圍 | MeasureCqlTab + 新增 ImportCqlFromLibraryDialog |
| 回歸風險 | 低 — 僅新增按鈕和對話框，不影響現有功能 |

## 安全性確認

- [x] 此變更不涉及安全性等級 B/C 的功能
- [x] 已評估 OWASP Top 10 安全風險
- [x] 無硬編碼敏感資訊

## IEC 62304 / ISO 14971 追溯

| 法規項目 | 關聯 Issue |
|----------|-----------|
| 軟體需求 | #81 |
| 軟體設計 | N/A — 安全性等級 A |
| 風險分析 | N/A — 安全性等級 A |
| 驗證紀錄 | N/A — 安全性等級 A |

🤖 Generated with [Claude Code](https://claude.com/claude-code)