### PR TITLE
docs: add commit hash to CHANGE_LOG #BUG-092

### DIFF
--- a/docs/CHANGE_LOG.md
+++ b/docs/CHANGE_LOG.md
@@ -9,6 +9,7 @@
 
 | ID | 類型 | 日期 | 範圍 | 標題 | 備註 | Commit |
 |-----|------|------|------|------|------|--------|
+| BUG-092 | 🔒 security | 2026-03-14 | 後端（依賴安全） | Jackson CVE 修復 — jackson-bom 2.21.1 (GHSA-72hv-8253-57qq) + tools.jackson 3.1.0 (CVE-2026-29062) — Security Scan 全綠 | logstash-logback-encoder 傳遞依賴 | [`ca9ebf7`](../../commit/ca9ebf7) |
 | PAT-056 | ✨ feature | 2026-03-14 | 前端（品質指標） | eCQM CQL Tab 從程式庫匯入 — 新增 ImportCqlFromLibraryDialog（搜尋/選擇/確認覆蓋）+ MeasureCqlTab 匯入按鈕，複用現有 CQL Libraries API | i18n EN+zh-TW | [`9a96f5f`](../../commit/9a96f5f) |
 | PAT-055 | ✨ feature | 2026-03-14 | 後端（CQL Engine） | CQL Framework 3.29→4.5.0 升級 — Kotlin Multiplatform 架構、groupId 遷移 (info→org.cqframework)、LibrarySourceProvider kotlinx.io.Source 適配、EvaluationParams builder、RestFhirRetrieveProvider +ModelResolver | 821 tests pass、6 檔案修改 | [`0d0f28a`](../../commit/0d0f28a) |
 | PAT-054 | 🔒 security | 2026-03-14 | 後端+CI（依賴升級） | Spring Boot 3.2→3.5.10 + HAPI FHIR 7.0→8.6.6 + Jackson 2.21.1 + ucum 1.0.9 + CI 密碼改 Secrets 參照 — 修復 Trivy CVE 掃描 + GitGuardian 告警 | 821 tests pass、Spring FW 6.2.x 對齊 | [`b532232`](../../commit/b532232) |


### PR DESCRIPTION
## 變更說明

更新 CHANGE_LOG.md，新增 BUG-092（Jackson CVE 修復）記錄。

## 變更類型

- [x] 文件更新 (docs)

## 關聯 Issue

Relates to #76

## 測試紀錄

N/A — 純文件變更

## 風險評估

| 項目 | 說明 |
|------|------|
| 風險等級 | 低 |
| 影響範圍 | docs/CHANGE_LOG.md |
| 回歸風險 | 無 |

## 安全性確認

- [x] 此變更不涉及安全性等級 B/C 的功能

## IEC 62304 / ISO 14971 追溯

| 法規項目 | 關聯 Issue |
|----------|-----------|
| 軟體需求 | #76 |
| 軟體設計 | N/A |
| 風險分析 | N/A |
| 驗證紀錄 | N/A |