### PR TITLE
feat: enhance CQL learning center with 8 improvements (#PAT-057)

### DIFF
--- a/frontend/src/components/learn/AdvancedTopics.tsx
+++ b/frontend/src/components/learn/AdvancedTopics.tsx
@@ -1,0 +1,146 @@
+import { Box, Typography, Paper, Grid } from '@mui/material'
+import { useTranslation } from 'react-i18next'
+import CodeBlock from './CodeBlock'
+
+const AGGREGATE_CODE = `library AggregateExample version '1.0.0'
+using FHIR version '4.0.1'
+include FHIRHelpers version '4.0.1'
+
+context Patient
+
+define "All Observations":
+  [Observation]
+
+define "Observation Count":
+  Count([Observation])
+
+define "Average Systolic BP":
+  Avg(
+    [Observation] O
+      where O.code.coding[0].code = '8480-6'
+      return (O.value as Quantity).value
+  )
+
+define "Total Lab Tests This Year":
+  Count(
+    [Observation] O
+      where O.effective during Interval[@2024-01-01, @2024-12-31]
+  )`
+
+const MULTI_SOURCE_CODE = `library MultiSourceExample version '1.0.0'
+using FHIR version '4.0.1'
+include FHIRHelpers version '4.0.1'
+
+context Patient
+
+define "Diabetic Patients on Metformin":
+  from [Condition] C, [MedicationRequest] M
+    where C.code.coding[0].code in { 'E11.9', 'E11.65' }
+      and M.medication.coding[0].display = 'Metformin'
+      and C.subject = M.subject
+    return { condition: C, medication: M }
+
+define "Encounters with Lab Results":
+  from [Encounter] E, [Observation] O
+    where O.encounter.reference = 'Encounter/' + E.id
+    return {
+      encounterDate: E.period.start,
+      labCode: O.code.coding[0].code,
+      labValue: O.value
+    }`
+
+const INTERVAL_CODE = `library IntervalExample version '1.0.0'
+using FHIR version '4.0.1'
+include FHIRHelpers version '4.0.1'
+
+parameter "Measurement Period" Interval<DateTime>
+  default Interval[@2024-01-01T00:00:00, @2024-12-31T23:59:59]
+
+context Patient
+
+// Overlaps: Two intervals share at least one point
+define "Active Conditions During Period":
+  [Condition] C
+    where Interval[C.onset, C.abatement] overlaps "Measurement Period"
+
+// During: One interval is entirely within another
+define "Labs During Measurement Period":
+  [Observation] O
+    where O.effective during "Measurement Period"
+
+// Meets: One interval ends exactly where another begins
+define "Consecutive Encounters":
+  from [Encounter] E1, [Encounter] E2
+    where E1.period meets E2.period
+
+// Width: Calculate the length of an interval
+define "Encounter Duration Days":
+  [Encounter] E
+    return duration in days of E.period`
+
+const TUPLE_CODE = `library TupleExample version '1.0.0'
+using FHIR version '4.0.1'
+include FHIRHelpers version '4.0.1'
+
+context Patient
+
+// Construct a Tuple with named fields
+define "Patient Summary":
+  Tuple {
+    patientId: Patient.id,
+    birthDate: Patient.birthDate,
+    age: AgeInYears(),
+    isAdult: AgeInYears() >= 18
+  }
+
+// Return Tuples from a query
+define "Lab Summary":
+  [Observation] O
+    return Tuple {
+      code: O.code.coding[0].code,
+      value: (O.value as Quantity).value,
+      unit: (O.value as Quantity).unit,
+      date: O.effective
+    }
+
+// Access Tuple fields
+define "Patient Age":
+  "Patient Summary".age`
+
+const TOPICS = [
+  { key: 'aggregate', code: AGGREGATE_CODE },
+  { key: 'multiSource', code: MULTI_SOURCE_CODE },
+  { key: 'intervals', code: INTERVAL_CODE },
+  { key: 'tuples', code: TUPLE_CODE },
+] as const
+
+export default function AdvancedTopics() {
+  const { t } = useTranslation('landing')
+
+  return (
+    <Box>
+      <Typography variant="h4" fontWeight={700} gutterBottom color="secondary.main">
+        {t('learn.advanced.title')}
+      </Typography>
+      <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
+        {t('learn.advanced.subtitle')}
+      </Typography>
+
+      <Grid spacing={3}>
+        {TOPICS.map(({ key, code }) => (
+          <Grid key={key} size={12}>
+            <Paper elevation={0} sx={{ p: 3, borderRadius: 3, border: '1px solid', borderColor: 'divider' }}>
+              <Typography variant="h6" fontWeight={700} gutterBottom color="primary.main">
+                {t(`learn.advanced.${key}.title`)}
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 2, lineHeight: 1.7 }}>
+                {t(`learn.advanced.${key}.description`)}
+              </Typography>
+              <CodeBlock code={code} maxHeight={400} />
+            </Paper>
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  )
+}

--- a/frontend/src/components/learn/CqlCheatSheet.tsx
+++ b/frontend/src/components/learn/CqlCheatSheet.tsx
@@ -1,0 +1,188 @@
+import {
+  Box,
+  Typography,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@mui/material'
+import { ExpandMore as ExpandMoreIcon } from '@mui/icons-material'
+import { useTranslation } from 'react-i18next'
+
+const DATA_TYPE_KEYS = [
+  'boolean', 'integer', 'decimal', 'string', 'dateTime',
+  'time', 'quantity', 'interval', 'list', 'tuple',
+] as const
+
+const OPERATOR_KEYS = [
+  'comparison', 'arithmetic', 'stringOps', 'dateTimeOps', 'listOps', 'logical',
+] as const
+
+const RETRIEVE_KEYS = ['basicRetrieve', 'codeFilter', 'dateFilter'] as const
+
+const FUNCTION_KEYS = [
+  'ageInYears', 'count', 'exists', 'first', 'last',
+  'sum', 'avg', 'toString', 'toDateTime', 'flatten',
+] as const
+
+export default function CqlCheatSheet() {
+  const { t } = useTranslation('landing')
+
+  return (
+    <Box>
+      <Typography variant="h4" fontWeight={700} gutterBottom color="secondary.main">
+        {t('learn.cheatSheet.title')}
+      </Typography>
+      <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
+        {t('learn.cheatSheet.subtitle')}
+      </Typography>
+
+      {/* Data Types */}
+      <Accordion defaultExpanded>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Typography variant="h6" fontWeight={700} color="primary.main">
+            {t('learn.cheatSheet.dataTypes.title')}
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <TableContainer>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell sx={{ fontWeight: 700 }}>{t('learn.cheatSheet.dataTypes.type')}</TableCell>
+                  <TableCell sx={{ fontWeight: 700 }}>{t('learn.cheatSheet.dataTypes.example')}</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {DATA_TYPE_KEYS.map((key) => (
+                  <TableRow key={key}>
+                    <TableCell>
+                      <Typography variant="body2" fontWeight={600}>{t(`learn.cheatSheet.dataTypes.${key}`)}</Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ fontFamily: 'monospace', color: 'primary.main' }}>
+                        {t(`learn.cheatSheet.dataTypes.${key}Ex`)}
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </AccordionDetails>
+      </Accordion>
+
+      {/* Operators */}
+      <Accordion>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Typography variant="h6" fontWeight={700} color="primary.main">
+            {t('learn.cheatSheet.operators.title')}
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <TableContainer>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell sx={{ fontWeight: 700 }}>{t('learn.cheatSheet.operators.category')}</TableCell>
+                  <TableCell sx={{ fontWeight: 700 }}>{t('learn.cheatSheet.operators.operatorCol')}</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {OPERATOR_KEYS.map((key) => (
+                  <TableRow key={key}>
+                    <TableCell>
+                      <Typography variant="body2" fontWeight={600}>{t(`learn.cheatSheet.operators.${key}`)}</Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                        {t(`learn.cheatSheet.operators.${key}Ops` as `learn.cheatSheet.operators.${string}`)}
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </AccordionDetails>
+      </Accordion>
+
+      {/* FHIR Retrieve Patterns */}
+      <Accordion>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Typography variant="h6" fontWeight={700} color="primary.main">
+            {t('learn.cheatSheet.retrieve.title')}
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <TableContainer>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell sx={{ fontWeight: 700 }}>{t('learn.cheatSheet.retrieve.pattern')}</TableCell>
+                  <TableCell sx={{ fontWeight: 700 }}>CQL</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {RETRIEVE_KEYS.map((key) => (
+                  <TableRow key={key}>
+                    <TableCell>
+                      <Typography variant="body2" fontWeight={600}>{t(`learn.cheatSheet.retrieve.${key}`)}</Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ fontFamily: 'monospace', color: 'primary.main' }}>
+                        {t(`learn.cheatSheet.retrieve.${key}Ex`)}
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </AccordionDetails>
+      </Accordion>
+
+      {/* Common Functions */}
+      <Accordion>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Typography variant="h6" fontWeight={700} color="primary.main">
+            {t('learn.cheatSheet.functions.title')}
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <TableContainer>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell sx={{ fontWeight: 700 }}>{t('learn.cheatSheet.functions.function')}</TableCell>
+                  <TableCell sx={{ fontWeight: 700 }}>{t('learn.cheatSheet.functions.description')}</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {FUNCTION_KEYS.map((key) => (
+                  <TableRow key={key}>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ fontFamily: 'monospace', fontWeight: 600 }}>
+                        {t(`learn.cheatSheet.functions.${key}`)}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" color="text.secondary">
+                        {t(`learn.cheatSheet.functions.${key}Desc`)}
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </AccordionDetails>
+      </Accordion>
+    </Box>
+  )
+}

--- a/frontend/src/components/learn/CqlPlayground.tsx
+++ b/frontend/src/components/learn/CqlPlayground.tsx
@@ -1,12 +1,15 @@
-import { useState, useCallback, useMemo } from 'react'
+import { useState, useCallback, useRef } from 'react'
 import { Box, Typography, Paper, Button, Alert, Grid, Menu, MenuItem } from '@mui/material'
 import {
   PlayArrow as TranslateIcon,
   ExpandMore as DropdownIcon,
 } from '@mui/icons-material'
 import { useTranslation } from 'react-i18next'
-import { useSelector } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
 import type { RootState } from '../../store'
+import { setCqlContent } from '../../store/editorSlice'
+import CqlEditor from '../editor/CqlEditor'
+import type { CqlEditorHandle } from '../editor/CqlEditor'
 import {
   CQL_PLAYGROUND_STARTER,
   CQL_EXAMPLE_DIABETES,
@@ -23,24 +26,23 @@ const TEMPLATES = [
   { key: 'encounter', code: CQL_EXAMPLE_ENCOUNTER },
 ] as const
 
-const TEMPLATE_LABELS: Record<string, string> = {
-  starter: 'Starter Template',
-  diabetes: 'Diabetes Care',
-  hypertension: 'Hypertension',
-  medication: 'Medication Safety',
-  encounter: 'Encounter Analysis',
-}
-
 export default function CqlPlayground() {
   const { t } = useTranslation('landing')
+  const dispatch = useDispatch()
   const isAuthenticated = useSelector((state: RootState) => state.auth.isAuthenticated)
-  const [code, setCode] = useState(CQL_PLAYGROUND_STARTER)
+  const cqlEditorRef = useRef<CqlEditorHandle>(null)
   const [result, setResult] = useState<{ success: boolean; message: string } | null>(null)
   const [loading, setLoading] = useState(false)
   const [templateAnchor, setTemplateAnchor] = useState<null | HTMLElement>(null)
+  const [lineCount, setLineCount] = useState(CQL_PLAYGROUND_STARTER.split('\n').length)
+
+  const handleContentChanged = useCallback((content: string) => {
+    setLineCount(content.split('\n').length)
+  }, [])
 
   const handleTranslate = useCallback(async () => {
     if (!isAuthenticated) return
+    const code = cqlEditorRef.current?.getContent() ?? ''
     setLoading(true)
     setResult(null)
     try {
@@ -60,15 +62,14 @@ export default function CqlPlayground() {
     } finally {
       setLoading(false)
     }
-  }, [code, isAuthenticated, t])
+  }, [isAuthenticated, t])
 
   const handleLoadTemplate = useCallback((templateCode: string) => {
-    setCode(templateCode)
+    dispatch(setCqlContent(templateCode))
+    setLineCount(templateCode.split('\n').length)
     setResult(null)
     setTemplateAnchor(null)
-  }, [])
-
-  const lineCount = useMemo(() => code.split('\n').length, [code])
+  }, [dispatch])
 
   return (
     <Box>
@@ -109,60 +110,21 @@ export default function CqlPlayground() {
               >
                 {TEMPLATES.map(({ key, code: templateCode }) => (
                   <MenuItem key={key} onClick={() => handleLoadTemplate(templateCode)}>
-                    {TEMPLATE_LABELS[key]}
+                    {t(`learn.playground.templates.${key}`)}
                   </MenuItem>
                 ))}
               </Menu>
               <Typography variant="caption" color="text.secondary" sx={{ ml: 'auto' }}>
-                {lineCount} lines
+                {t('learn.playground.lines', { count: lineCount })}
               </Typography>
             </Box>
 
-            {/* Editor */}
-            <Box sx={{ display: 'flex' }}>
-              {/* Line numbers */}
-              <Box
-                sx={{
-                  p: 2,
-                  pr: 1,
-                  bgcolor: '#1E1E2E',
-                  color: 'rgba(255,255,255,0.25)',
-                  fontFamily: '"Fira Code", monospace',
-                  fontSize: '0.82rem',
-                  lineHeight: 1.6,
-                  textAlign: 'right',
-                  userSelect: 'none',
-                  minWidth: 40,
-                  whiteSpace: 'pre-line',
-                }}
-              >
-                {Array.from({ length: lineCount }, (_, i) => i + 1).join('\n')}
-              </Box>
-              {/* Textarea */}
-              <Box
-                component="textarea"
-                value={code}
-                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setCode(e.target.value)}
-                spellCheck={false}
-                sx={{
-                  flex: 1,
-                  p: 2,
-                  pl: 1,
-                  bgcolor: '#1E1E2E',
-                  color: '#D4D4D4',
-                  fontFamily: '"Fira Code", "Cascadia Code", monospace',
-                  fontSize: '0.82rem',
-                  lineHeight: 1.6,
-                  border: 'none',
-                  outline: 'none',
-                  resize: 'vertical',
-                  minHeight: 400,
-                  width: '100%',
-                  whiteSpace: 'pre',
-                  overflowX: 'auto',
-                }}
-              />
-            </Box>
+            {/* Monaco Editor */}
+            <CqlEditor
+              ref={cqlEditorRef}
+              height={400}
+              onContentChanged={handleContentChanged}
+            />
           </Paper>
         </Grid>
 

--- a/frontend/src/components/learn/CqlQuiz.tsx
+++ b/frontend/src/components/learn/CqlQuiz.tsx
@@ -9,13 +9,30 @@ import {
   Radio,
   Alert,
   LinearProgress,
+  Chip,
 } from '@mui/material'
 import { useTranslation } from 'react-i18next'
+import { useSearchParams } from 'react-router-dom'
 
 const QUESTION_COUNT = 10
 
+// Topic mapping: question index -> topic key
+const TOPIC_MAP: Record<number, { key: string; tab: string }> = {
+  0: { key: 'terminology', tab: 'concepts' },
+  1: { key: 'terminology', tab: 'concepts' },
+  2: { key: 'syntax', tab: 'concepts' },
+  3: { key: 'concepts', tab: 'concepts' },
+  4: { key: 'twcore', tab: 'twcore' },
+  5: { key: 'concepts', tab: 'concepts' },
+  6: { key: 'twcore', tab: 'twcore' },
+  7: { key: 'syntax', tab: 'concepts' },
+  8: { key: 'standards', tab: 'twcore' },
+  9: { key: 'standards', tab: 'introduction' },
+}
+
 export default function CqlQuiz() {
   const { t } = useTranslation('landing')
+  const [, setSearchParams] = useSearchParams()
   const [currentQ, setCurrentQ] = useState(0)
   const [selectedAnswer, setSelectedAnswer] = useState<number | null>(null)
   const [checked, setChecked] = useState(false)
@@ -57,7 +74,26 @@ export default function CqlQuiz() {
     setFinished(false)
   }, [])
 
+  const handleNavigateToTab = useCallback((tab: string) => {
+    setSearchParams({ tab })
+  }, [setSearchParams])
+
   const totalCorrect = scores.filter(Boolean).length
+
+  // Compute missed topics from wrong answers
+  const missedTopics = useMemo(() => {
+    if (!finished) return []
+    const topicSet = new Map<string, string>()
+    scores.forEach((correct, index) => {
+      if (!correct) {
+        const topic = TOPIC_MAP[index]
+        if (topic && !topicSet.has(topic.key)) {
+          topicSet.set(topic.key, topic.tab)
+        }
+      }
+    })
+    return Array.from(topicSet.entries()).map(([key, tab]) => ({ key, tab }))
+  }, [finished, scores])
 
   if (finished) {
     const ratio = totalCorrect / QUESTION_COUNT
@@ -90,6 +126,28 @@ export default function CqlQuiz() {
           <Typography variant="body1" color="text.secondary" sx={{ mb: 3, lineHeight: 1.7 }}>
             {t(`learn.quiz.${feedbackKey}`)}
           </Typography>
+
+          {missedTopics.length > 0 && (
+            <Box sx={{ mb: 3 }}>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                {t('learn.quiz.reviewTopics')}
+              </Typography>
+              <Box sx={{ display: 'flex', gap: 1, justifyContent: 'center', flexWrap: 'wrap' }}>
+                {missedTopics.map(({ key, tab }) => (
+                  <Chip
+                    key={key}
+                    label={t(`learn.quiz.topics.${key}`)}
+                    color="warning"
+                    variant="outlined"
+                    clickable
+                    onClick={() => handleNavigateToTab(tab)}
+                    sx={{ fontWeight: 600 }}
+                  />
+                ))}
+              </Box>
+            </Box>
+          )}
+
           <Button variant="contained" onClick={handleRestart} sx={{ textTransform: 'none', px: 4 }}>
             {t('learn.quiz.restart')}
           </Button>

--- a/frontend/src/components/learn/InteractiveExamples.tsx
+++ b/frontend/src/components/learn/InteractiveExamples.tsx
@@ -1,12 +1,16 @@
 import { useState, useCallback } from 'react'
-import { Box, Typography, Paper, Grid, List, ListItemButton, ListItemIcon, ListItemText } from '@mui/material'
+import { Box, Typography, Paper, Grid, List, ListItemButton, ListItemIcon, ListItemText, Button } from '@mui/material'
 import {
   Bloodtype as DiabetesIcon,
   MonitorHeart as HypertensionIcon,
   Medication as MedicationIcon,
   EventNote as EncounterIcon,
+  OpenInNew as OpenInEditorIcon,
 } from '@mui/icons-material'
 import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
+import { useDispatch } from 'react-redux'
+import { setCqlContent } from '../../store/editorSlice'
 import CodeBlock from './CodeBlock'
 import {
   CQL_EXAMPLE_DIABETES,
@@ -24,11 +28,18 @@ const EXAMPLES = [
 
 export default function InteractiveExamples() {
   const { t } = useTranslation('landing')
+  const navigate = useNavigate()
+  const dispatch = useDispatch()
   const [selected, setSelected] = useState(0)
 
   const handleSelect = useCallback((index: number) => {
     setSelected(index)
   }, [])
+
+  const handleOpenInEditor = useCallback(() => {
+    dispatch(setCqlContent(EXAMPLES[selected].code))
+    navigate('/')
+  }, [dispatch, navigate, selected])
 
   const example = EXAMPLES[selected]
 
@@ -80,9 +91,18 @@ export default function InteractiveExamples() {
         <Grid size={{ xs: 12, md: 8 }}>
           <Paper elevation={0} sx={{ borderRadius: 3, border: '1px solid', borderColor: 'divider', overflow: 'hidden' }}>
             <Box sx={{ p: 2, borderBottom: 1, borderColor: 'divider', display: 'flex', alignItems: 'center', gap: 1 }}>
-              <Typography variant="subtitle1" fontWeight={700}>
+              <Typography variant="subtitle1" fontWeight={700} sx={{ flex: 1 }}>
                 {t(`learn.examples.${example.key}.title`)}
               </Typography>
+              <Button
+                size="small"
+                variant="outlined"
+                startIcon={<OpenInEditorIcon />}
+                onClick={handleOpenInEditor}
+                sx={{ textTransform: 'none' }}
+              >
+                {t('learn.examples.openInEditor')}
+              </Button>
             </Box>
             <CodeBlock code={example.code} maxHeight={400} />
             <Box sx={{ p: 2.5, bgcolor: 'action.hover' }}>

--- a/frontend/src/components/learn/TroubleshootingGuide.tsx
+++ b/frontend/src/components/learn/TroubleshootingGuide.tsx
@@ -1,0 +1,141 @@
+import { Box, Typography, Paper, Grid, Alert } from '@mui/material'
+import { useTranslation } from 'react-i18next'
+import CodeBlock from './CodeBlock'
+
+const ERROR_FIXES: Record<string, string> = {
+  resolveType: `library MyLibrary version '1.0.0'
+using FHIR version '4.0.1'   // <-- Add this line
+include FHIRHelpers version '4.0.1'
+
+context Patient
+
+define "All Conditions":
+  [Condition]`,
+
+  resolveContext: `library MyLibrary version '1.0.0'
+using FHIR version '4.0.1'
+
+// Correct: use 'Patient' (singular, capitalized)
+context Patient
+
+define "Example":
+  [Observation]`,
+
+  invokeMember: `library MyLibrary version '1.0.0'
+using FHIR version '4.0.1'
+include FHIRHelpers version '4.0.1'
+
+context Patient
+
+// Wrong: [Observation].value  (list, not single element)
+// Correct: use a query alias
+define "Observation Values":
+  [Observation] O
+    where O.value is not null
+    return O.value`,
+
+  resolveCodeSystem: `library MyLibrary version '1.0.0'
+using FHIR version '4.0.1'
+include FHIRHelpers version '4.0.1'
+
+// Declare code systems before using them
+codesystem "LOINC": 'http://loinc.org'
+codesystem "ICD10": 'http://hl7.org/fhir/sid/icd-10-cm'
+
+code "HbA1c": '4548-4' from "LOINC"
+
+context Patient
+
+define "HbA1c Tests":
+  [Observation: "HbA1c"]`,
+
+  timeout: `// Before (complex nested query):
+define "Complex":
+  [Observation] O
+    where exists (
+      [Condition] C
+        where exists (
+          [MedicationRequest] M
+            where M.subject = C.subject
+        )
+    )
+
+// After (split into smaller definitions):
+define "Active Medications":
+  [MedicationRequest] M
+    where M.status = 'active'
+
+define "Active Conditions":
+  [Condition] C
+    where C.clinicalStatus.coding[0].code = 'active'
+
+define "Patients with Both":
+  exists "Active Conditions"
+    and exists "Active Medications"`,
+
+  noResults: `library MyLibrary version '1.0.0'
+using FHIR version '4.0.1'
+include FHIRHelpers version '4.0.1'
+
+// Check: Is the Measurement Period correct?
+parameter "Measurement Period" Interval<DateTime>
+  default Interval[@2024-01-01T00:00:00, @2024-12-31T23:59:59]
+
+context Patient
+
+// Start simple to verify data exists
+define "All Conditions":
+  [Condition]
+
+define "Condition Count":
+  Count([Condition])
+
+// Then add filters gradually
+define "Active Conditions":
+  [Condition] C
+    where C.clinicalStatus.coding[0].code = 'active'`,
+}
+
+const ERROR_KEYS = ['resolveType', 'resolveContext', 'invokeMember', 'resolveCodeSystem', 'timeout', 'noResults'] as const
+
+export default function TroubleshootingGuide() {
+  const { t } = useTranslation('landing')
+
+  return (
+    <Box>
+      <Typography variant="h4" fontWeight={700} gutterBottom color="secondary.main">
+        {t('learn.troubleshooting.title')}
+      </Typography>
+      <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
+        {t('learn.troubleshooting.subtitle')}
+      </Typography>
+
+      <Grid spacing={3}>
+        {ERROR_KEYS.map((key) => (
+          <Grid key={key} size={12}>
+            <Paper elevation={0} sx={{ p: 3, borderRadius: 3, border: '1px solid', borderColor: 'divider' }}>
+              <Typography variant="h6" fontWeight={700} gutterBottom color="primary.main">
+                {t(`learn.troubleshooting.errors.${key}.title`)}
+              </Typography>
+
+              <Alert severity="error" sx={{ mb: 2, fontFamily: 'monospace', fontSize: '0.85rem' }}>
+                {t(`learn.troubleshooting.errors.${key}.error`)}
+              </Alert>
+
+              <Alert severity="success" sx={{ mb: 2 }}>
+                <Typography variant="body2" fontWeight={600} gutterBottom>
+                  {t(`learn.troubleshooting.errors.${key}.fix`)}
+                </Typography>
+                <Typography variant="body2">
+                  {t(`learn.troubleshooting.errors.${key}.solution`)}
+                </Typography>
+              </Alert>
+
+              <CodeBlock code={ERROR_FIXES[key]} maxHeight={300} />
+            </Paper>
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  )
+}

--- a/frontend/src/components/learn/TwcoreGuide.tsx
+++ b/frontend/src/components/learn/TwcoreGuide.tsx
@@ -55,9 +55,9 @@ export default function TwcoreGuide() {
               <Table size="small">
                 <TableHead>
                   <TableRow>
-                    <TableCell sx={{ fontWeight: 700 }}>FHIR Resource</TableCell>
-                    <TableCell sx={{ fontWeight: 700 }}>TWCORE Profile</TableCell>
-                    <TableCell sx={{ fontWeight: 700 }}>Description</TableCell>
+                    <TableCell sx={{ fontWeight: 700 }}>{t('learn.twcore.headers.resource')}</TableCell>
+                    <TableCell sx={{ fontWeight: 700 }}>{t('learn.twcore.headers.profile')}</TableCell>
+                    <TableCell sx={{ fontWeight: 700 }}>{t('learn.twcore.headers.description')}</TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>

--- a/frontend/src/locales/en/landing.json
+++ b/frontend/src/locales/en/landing.json
@@ -46,6 +46,9 @@
       "twcore": "TWCORE IG",
       "examples": "Interactive Examples",
       "quickStart": "Quick Start",
+      "advanced": "Advanced Topics",
+      "troubleshooting": "Troubleshooting",
+      "cheatSheet": "Cheat Sheet",
       "playground": "Playground",
       "quiz": "Self Quiz"
     },
@@ -140,12 +143,18 @@
       "example": {
         "title": "Full Example: Diabetes Care Quality Measure",
         "description": "The following example demonstrates how to use CQL + TWCORE IG to define a diabetes care quality measure calculating HbA1c screening completion rate."
+      },
+      "headers": {
+        "resource": "FHIR Resource",
+        "profile": "TWCORE Profile",
+        "description": "Description"
       }
     },
     "examples": {
       "title": "Interactive Examples",
       "subtitle": "Click an example to view CQL code and detailed explanation",
       "tryInEditor": "Open in Editor",
+      "openInEditor": "Open in Editor",
       "copyCode": "Copy Code",
       "copied": "Copied!",
       "diabetes": {
@@ -209,7 +218,15 @@
       "success": "Translation successful! CQL syntax is correct.",
       "errors": "Translation found {{count}} issue(s):",
       "loginRequired": "Login to use full translation features",
-      "loginToTranslate": "Login to Translate"
+      "loginToTranslate": "Login to Translate",
+      "lines": "{{count}} lines",
+      "templates": {
+        "starter": "Starter Template",
+        "diabetes": "Diabetes Care",
+        "hypertension": "Hypertension",
+        "medication": "Medication Safety",
+        "encounter": "Encounter Analysis"
+      }
     },
     "quiz": {
       "title": "CQL Self Quiz",
@@ -224,6 +241,231 @@
       "needsWork": "Keep learning! Review the Introduction and Core Concepts sections.",
       "correct": "Correct!",
       "incorrect": "Incorrect.",
+      "q1": {
+        "question": "What does CQL stand for?",
+        "options": ["Clinical Query Language", "Clinical Quality Language", "Computer Query Language", "Clinical Quantitative Language"],
+        "answer": 1,
+        "explanation": "CQL stands for Clinical Quality Language, developed by HL7 International."
+      },
+      "q2": {
+        "question": "Which data model does CQL use to access clinical data?",
+        "options": ["HL7 V2", "CDA", "FHIR", "DICOM"],
+        "answer": 2,
+        "explanation": "CQL is built on top of the FHIR (Fast Healthcare Interoperability Resources) data model."
+      },
+      "q3": {
+        "question": "How do you query all Condition resources in CQL?",
+        "options": ["SELECT * FROM Condition", "[Condition]", "query Condition", "get(Condition)"],
+        "answer": 1,
+        "explanation": "CQL uses bracket syntax [ResourceType] to query FHIR resources, e.g., [Condition] retrieves all Condition resources."
+      },
+      "q4": {
+        "question": "What is the compiled intermediate format of CQL called?",
+        "options": ["AST", "ELM", "XML", "JSON-LD"],
+        "answer": 1,
+        "explanation": "CQL is compiled to ELM (Expression Logical Model), a machine-executable logical model."
+      },
+      "q5": {
+        "question": "Which organization developed the TWCORE IG?",
+        "options": ["HL7 International", "WHO", "Ministry of Health and Welfare (Taiwan)", "National Health Insurance Administration"],
+        "answer": 2,
+        "explanation": "TWCORE IG is developed by Taiwan's Ministry of Health and Welfare based on HL7 FHIR R4."
+      },
+      "q6": {
+        "question": "What does 'context Patient' do in CQL?",
+        "options": ["Declares a patient variable", "Scopes queries to the currently evaluated patient", "Defines patient data structure", "Imports patient database"],
+        "answer": 1,
+        "explanation": "'context Patient' scopes all subsequent queries to the currently evaluated patient."
+      },
+      "q7": {
+        "question": "Which terminology system is primarily used for diagnoses in Taiwan?",
+        "options": ["SNOMED CT", "LOINC", "ICD-10-CM-TW", "RxNorm"],
+        "answer": 2,
+        "explanation": "Taiwan primarily uses ICD-10-CM-TW for diagnosis coding."
+      },
+      "q8": {
+        "question": "What does the 'define' keyword do in CQL?",
+        "options": ["Defines a variable", "Creates a named reusable expression", "Declares a library", "Defines a data type"],
+        "answer": 1,
+        "explanation": "'define' creates named expressions that can be referenced by other definitions — CQL's core building blocks."
+      },
+      "q9": {
+        "question": "What lab test does LOINC code 4548-4 correspond to?",
+        "options": ["Glucose", "Creatinine", "HbA1c", "Cholesterol"],
+        "answer": 2,
+        "explanation": "LOINC 4548-4 corresponds to Hemoglobin A1c/Hemoglobin.total in Blood (HbA1c)."
+      },
+      "q10": {
+        "question": "What does eCQM stand for?",
+        "options": ["electronic Clinical Quality Model", "electronic Clinical Quality Measure", "electronic Care Quality Metric", "electronic Clinical Quantitative Measure"],
+        "answer": 1,
+        "explanation": "eCQM stands for electronic Clinical Quality Measure, using CQL for measure logic definition."
+      }
+    },
+    "advanced": {
+      "title": "Advanced CQL Topics",
+      "subtitle": "Explore advanced CQL patterns for complex clinical logic",
+      "aggregate": {
+        "title": "Aggregate Queries",
+        "description": "Use aggregate functions like Count, Sum, and Avg to compute statistics over FHIR data collections."
+      },
+      "multiSource": {
+        "title": "Combined Queries (Multiple Sources)",
+        "description": "Query multiple FHIR resource types simultaneously and correlate data across them using multi-source queries."
+      },
+      "intervals": {
+        "title": "Interval Operations",
+        "description": "CQL provides rich interval operations for working with date ranges and numeric intervals: overlaps, during, meets, and more."
+      },
+      "tuples": {
+        "title": "Tuple Construction & Access",
+        "description": "Tuples let you create structured data with named fields, useful for returning composite results from definitions."
+      }
+    },
+    "troubleshooting": {
+      "title": "Troubleshooting Guide",
+      "subtitle": "Common CQL errors and how to fix them",
+      "errors": {
+        "resolveType": {
+          "title": "Could not resolve type",
+          "error": "Could not resolve type name 'Patient'",
+          "solution": "Add the FHIR model declaration at the top of your library. This tells CQL which data model to use for resolving resource types.",
+          "fix": "Add 'using FHIR version '4.0.1'' after your library declaration"
+        },
+        "resolveContext": {
+          "title": "Could not resolve context",
+          "error": "Could not resolve context name 'Patients'",
+          "solution": "Use the correct context name. Valid contexts are 'Patient', 'Practitioner', 'Encounter', or 'Unfiltered'. The most common is 'Patient'.",
+          "fix": "Use 'context Patient' (singular, capitalized)"
+        },
+        "invokeMember": {
+          "title": "Cannot invoke member",
+          "error": "Cannot invoke member 'value' on type 'List<FHIR.Observation>'",
+          "solution": "You're trying to access a property on a list instead of a single element. Use a query alias to access individual elements.",
+          "fix": "Use a query: [Observation] O where O.value is not null"
+        },
+        "resolveCodeSystem": {
+          "title": "Could not resolve code system",
+          "error": "Could not resolve code system name 'LOINC'",
+          "solution": "Declare the code system before referencing it. Code systems must be declared with their canonical URL.",
+          "fix": "Add: codesystem \"LOINC\": 'http://loinc.org'"
+        },
+        "timeout": {
+          "title": "Translation Timeout",
+          "error": "Translation timed out after 30 seconds",
+          "solution": "Your CQL may be too complex. Break down large expressions into smaller define statements, reduce nested queries, or simplify logic.",
+          "fix": "Split complex expressions into multiple simpler definitions"
+        },
+        "noResults": {
+          "title": "No Results Returned",
+          "error": "All definitions returned null or empty results",
+          "solution": "Check that your FHIR server has matching data. Verify date ranges in your Measurement Period, code system URIs, and value set OIDs match the data on the server.",
+          "fix": "Verify data exists: check patient IDs, date ranges, and terminology codes"
+        }
+      }
+    },
+    "cheatSheet": {
+      "title": "CQL Quick Reference",
+      "subtitle": "A concise cheat sheet for CQL syntax and common patterns",
+      "dataTypes": {
+        "title": "Data Types",
+        "type": "Type",
+        "example": "Example",
+        "boolean": "Boolean",
+        "booleanEx": "true, false",
+        "integer": "Integer",
+        "integerEx": "42, -7",
+        "decimal": "Decimal",
+        "decimalEx": "3.14, -0.5",
+        "string": "String",
+        "stringEx": "'Hello World'",
+        "dateTime": "DateTime",
+        "dateTimeEx": "@2024-01-15T08:30:00",
+        "time": "Time",
+        "timeEx": "@T14:30:00",
+        "quantity": "Quantity",
+        "quantityEx": "120 'mmHg'",
+        "interval": "Interval",
+        "intervalEx": "Interval[1, 10]",
+        "list": "List",
+        "listEx": "{ 1, 2, 3 }",
+        "tuple": "Tuple",
+        "tupleEx": "Tuple { name: 'test', value: 1 }"
+      },
+      "operators": {
+        "title": "Operators",
+        "category": "Category",
+        "operatorCol": "Operator",
+        "comparison": "Comparison",
+        "comparisonOps": "=, !=, <, >, <=, >=, ~, !~",
+        "arithmetic": "Arithmetic",
+        "arithmeticOps": "+, -, *, /, div, mod",
+        "stringOps": "String",
+        "stringOpsVal": "+, &, Length(), IndexOf(), Substring()",
+        "dateTimeOps": "DateTime",
+        "dateTimeOpsVal": "+, -, duration in, difference in",
+        "listOps": "List",
+        "listOpsVal": "in, contains, includes, union, intersect, except",
+        "logical": "Logical",
+        "logicalOps": "and, or, not, xor, implies"
+      },
+      "retrieve": {
+        "title": "FHIR Retrieve Patterns",
+        "pattern": "Pattern",
+        "basicRetrieve": "Basic retrieve",
+        "basicRetrieveEx": "[Condition]",
+        "codeFilter": "With code filter",
+        "codeFilterEx": "[Condition: \"Diabetes\"]",
+        "dateFilter": "With date filter",
+        "dateFilterEx": "[Observation] O where O.effective during \"Measurement Period\""
+      },
+      "functions": {
+        "title": "Common Functions",
+        "function": "Function",
+        "description": "Description",
+        "ageInYears": "AgeInYears()",
+        "ageInYearsDesc": "Patient's age in years at evaluation time",
+        "count": "Count(list)",
+        "countDesc": "Number of elements in a list",
+        "exists": "exists(list)",
+        "existsDesc": "True if list has at least one element",
+        "first": "First(list)",
+        "firstDesc": "First element of a list",
+        "last": "Last(list)",
+        "lastDesc": "Last element of a list",
+        "sum": "Sum(list)",
+        "sumDesc": "Sum of numeric elements",
+        "avg": "Avg(list)",
+        "avgDesc": "Average of numeric elements",
+        "toString": "ToString(value)",
+        "toStringDesc": "Convert value to string representation",
+        "toDateTime": "ToDateTime(value)",
+        "toDateTimeDesc": "Convert value to DateTime",
+        "flatten": "Flatten(list)",
+        "flattenDesc": "Flatten nested lists into a single list"
+      }
+    },
+    "quiz": {
+      "title": "CQL Self Quiz",
+      "subtitle": "Test your understanding of CQL core concepts",
+      "question": "Question {{current}} of {{total}}",
+      "checkAnswer": "Check Answer",
+      "next": "Next",
+      "restart": "Restart Quiz",
+      "score": "Your score: {{score}} / {{total}}",
+      "perfect": "Perfect score! You've mastered CQL core concepts.",
+      "good": "Well done! Consider reviewing the questions you missed.",
+      "needsWork": "Keep learning! Review the Introduction and Core Concepts sections.",
+      "correct": "Correct!",
+      "incorrect": "Incorrect.",
+      "reviewTopics": "Topics to review:",
+      "topics": {
+        "terminology": "Terminology",
+        "syntax": "Syntax",
+        "concepts": "Concepts",
+        "twcore": "TWCORE",
+        "standards": "Standards"
+      },
       "q1": {
         "question": "What does CQL stand for?",
         "options": ["Clinical Query Language", "Clinical Quality Language", "Computer Query Language", "Clinical Quantitative Language"],

--- a/frontend/src/locales/zh-TW/landing.json
+++ b/frontend/src/locales/zh-TW/landing.json
@@ -46,6 +46,9 @@
       "twcore": "TWCORE IG",
       "examples": "互動範例",
       "quickStart": "快速開始",
+      "advanced": "進階主題",
+      "troubleshooting": "疑難排解",
+      "cheatSheet": "速查表",
       "playground": "練習場",
       "quiz": "自我測驗"
     },
@@ -140,12 +143,18 @@
       "example": {
         "title": "完整範例：糖尿病照護品質指標",
         "description": "以下範例展示如何使用 CQL + TWCORE IG 定義一個糖尿病照護品質指標，計算 HbA1c 檢驗完成率。"
+      },
+      "headers": {
+        "resource": "FHIR 資源",
+        "profile": "TWCORE Profile",
+        "description": "說明"
       }
     },
     "examples": {
       "title": "互動範例",
       "subtitle": "點選範例查看 CQL 程式碼與詳細說明",
       "tryInEditor": "在編輯器中開啟",
+      "openInEditor": "在編輯器中開啟",
       "copyCode": "複製程式碼",
       "copied": "已複製！",
       "diabetes": {
@@ -209,7 +218,15 @@
       "success": "翻譯成功！CQL 語法正確。",
       "errors": "翻譯發現 {{count}} 個問題：",
       "loginRequired": "登入後可使用完整的翻譯功能",
-      "loginToTranslate": "登入以翻譯"
+      "loginToTranslate": "登入以翻譯",
+      "lines": "{{count}} 行",
+      "templates": {
+        "starter": "入門範本",
+        "diabetes": "糖尿病照護",
+        "hypertension": "高血壓",
+        "medication": "用藥安全",
+        "encounter": "就醫分析"
+      }
     },
     "quiz": {
       "title": "CQL 自我測驗",
@@ -224,6 +241,231 @@
       "needsWork": "還需要加油！建議先閱讀入門介紹和核心概念。",
       "correct": "正確！",
       "incorrect": "不正確。",
+      "q1": {
+        "question": "CQL 的全稱是什麼？",
+        "options": ["Clinical Query Language", "Clinical Quality Language", "Computer Query Language", "Clinical Quantitative Language"],
+        "answer": 1,
+        "explanation": "CQL 全稱 Clinical Quality Language（臨床品質語言），由 HL7 International 制定。"
+      },
+      "q2": {
+        "question": "CQL 使用哪個資料模型來存取臨床資料？",
+        "options": ["HL7 V2", "CDA", "FHIR", "DICOM"],
+        "answer": 2,
+        "explanation": "CQL 建立在 FHIR（Fast Healthcare Interoperability Resources）資料模型之上。"
+      },
+      "q3": {
+        "question": "在 CQL 中，如何查詢所有的 Condition（診斷）資源？",
+        "options": ["SELECT * FROM Condition", "[Condition]", "query Condition", "get(Condition)"],
+        "answer": 1,
+        "explanation": "CQL 使用方括號語法 [ResourceType] 來查詢 FHIR 資源，例如 [Condition] 查詢所有診斷資源。"
+      },
+      "q4": {
+        "question": "CQL 被編譯後產生的中間格式稱為什麼？",
+        "options": ["AST", "ELM", "XML", "JSON-LD"],
+        "answer": 1,
+        "explanation": "CQL 被編譯為 ELM（Expression Logical Model），這是一種機器可執行的邏輯模型。"
+      },
+      "q5": {
+        "question": "TWCORE IG 是由哪個機構制定的？",
+        "options": ["HL7 International", "WHO", "衛生福利部", "健保署"],
+        "answer": 2,
+        "explanation": "TWCORE IG（台灣核心實作指引）是衛生福利部依 HL7 FHIR R4 規範制定的在地化標準。"
+      },
+      "q6": {
+        "question": "在 CQL 中，'context Patient' 的作用是什麼？",
+        "options": ["宣告病患變數", "限定查詢範圍為目前評估的病患", "定義病患資料結構", "匯入病患資料庫"],
+        "answer": 1,
+        "explanation": "context Patient 將所有後續查詢的範圍限定為目前正在評估的病患。"
+      },
+      "q7": {
+        "question": "台灣的診斷碼主要使用哪個術語系統？",
+        "options": ["SNOMED CT", "LOINC", "ICD-10-CM-TW", "RxNorm"],
+        "answer": 2,
+        "explanation": "台灣主要使用 ICD-10-CM-TW（台灣國際疾病分類）作為診斷編碼系統。"
+      },
+      "q8": {
+        "question": "CQL 中 define 關鍵字的作用是什麼？",
+        "options": ["定義變數", "建立具名的可重用運算式", "宣告函式庫", "定義資料類型"],
+        "answer": 1,
+        "explanation": "define 建立具名的運算式，可被其他定義引用，是 CQL 的核心建構區塊。"
+      },
+      "q9": {
+        "question": "LOINC 代碼 4548-4 對應的檢驗項目是什麼？",
+        "options": ["血糖（Glucose）", "肌酸酐（Creatinine）", "糖化血色素（HbA1c）", "膽固醇（Cholesterol）"],
+        "answer": 2,
+        "explanation": "LOINC 4548-4 對應 Hemoglobin A1c/Hemoglobin.total in Blood，即糖化血色素（HbA1c）。"
+      },
+      "q10": {
+        "question": "eCQM 的全稱是什麼？",
+        "options": ["electronic Clinical Quality Model", "electronic Clinical Quality Measure", "electronic Care Quality Metric", "electronic Clinical Quantitative Measure"],
+        "answer": 1,
+        "explanation": "eCQM 全稱 electronic Clinical Quality Measure（電子臨床品質指標），使用 CQL 定義量測邏輯。"
+      }
+    },
+    "advanced": {
+      "title": "CQL 進階主題",
+      "subtitle": "探索進階 CQL 模式，處理複雜臨床邏輯",
+      "aggregate": {
+        "title": "聚合查詢",
+        "description": "使用 Count、Sum、Avg 等聚合函式對 FHIR 資料集合進行統計計算。"
+      },
+      "multiSource": {
+        "title": "組合查詢（多資料來源）",
+        "description": "同時查詢多個 FHIR 資源類型，並透過多來源查詢在資源之間建立關聯。"
+      },
+      "intervals": {
+        "title": "區間運算",
+        "description": "CQL 提供豐富的區間運算，用於處理日期範圍和數值區間：overlaps、during、meets 等。"
+      },
+      "tuples": {
+        "title": "Tuple 建構與存取",
+        "description": "Tuple 讓您建立帶有具名欄位的結構化資料，適合從定義中回傳複合結果。"
+      }
+    },
+    "troubleshooting": {
+      "title": "疑難排解指南",
+      "subtitle": "常見 CQL 錯誤及解決方法",
+      "errors": {
+        "resolveType": {
+          "title": "無法解析類型",
+          "error": "Could not resolve type name 'Patient'",
+          "solution": "在函式庫最上方加入 FHIR 資料模型宣告。這會告訴 CQL 要使用哪個資料模型來解析資源類型。",
+          "fix": "在 library 宣告後加入 'using FHIR version '4.0.1''"
+        },
+        "resolveContext": {
+          "title": "無法解析上下文",
+          "error": "Could not resolve context name 'Patients'",
+          "solution": "使用正確的上下文名稱。有效的上下文為 'Patient'、'Practitioner'、'Encounter' 或 'Unfiltered'，最常用的是 'Patient'。",
+          "fix": "使用 'context Patient'（單數、大寫開頭）"
+        },
+        "invokeMember": {
+          "title": "無法呼叫成員",
+          "error": "Cannot invoke member 'value' on type 'List<FHIR.Observation>'",
+          "solution": "您正在嘗試對列表而非單一元素存取屬性。請使用查詢別名來存取個別元素。",
+          "fix": "使用查詢：[Observation] O where O.value is not null"
+        },
+        "resolveCodeSystem": {
+          "title": "無法解析代碼系統",
+          "error": "Could not resolve code system name 'LOINC'",
+          "solution": "在引用之前先宣告代碼系統。代碼系統必須使用其標準 URL 來宣告。",
+          "fix": "加入：codesystem \"LOINC\": 'http://loinc.org'"
+        },
+        "timeout": {
+          "title": "翻譯逾時",
+          "error": "Translation timed out after 30 seconds",
+          "solution": "您的 CQL 可能太複雜。將大型運算式拆分為較小的 define 語句，減少巢狀查詢，或簡化邏輯。",
+          "fix": "將複雜運算式拆分為多個較簡單的定義"
+        },
+        "noResults": {
+          "title": "沒有回傳結果",
+          "error": "All definitions returned null or empty results",
+          "solution": "檢查您的 FHIR 伺服器是否有符合的資料。驗證量測期間的日期範圍、代碼系統 URI 及值集 OID 是否與伺服器上的資料相符。",
+          "fix": "確認資料存在：檢查病患 ID、日期範圍與術語代碼"
+        }
+      }
+    },
+    "cheatSheet": {
+      "title": "CQL 速查表",
+      "subtitle": "CQL 語法與常用模式的簡明參考",
+      "dataTypes": {
+        "title": "資料類型",
+        "type": "類型",
+        "example": "範例",
+        "boolean": "布林值",
+        "booleanEx": "true, false",
+        "integer": "整數",
+        "integerEx": "42, -7",
+        "decimal": "小數",
+        "decimalEx": "3.14, -0.5",
+        "string": "字串",
+        "stringEx": "'Hello World'",
+        "dateTime": "日期時間",
+        "dateTimeEx": "@2024-01-15T08:30:00",
+        "time": "時間",
+        "timeEx": "@T14:30:00",
+        "quantity": "數量",
+        "quantityEx": "120 'mmHg'",
+        "interval": "區間",
+        "intervalEx": "Interval[1, 10]",
+        "list": "列表",
+        "listEx": "{ 1, 2, 3 }",
+        "tuple": "Tuple",
+        "tupleEx": "Tuple { name: 'test', value: 1 }"
+      },
+      "operators": {
+        "title": "運算子",
+        "category": "類別",
+        "operatorCol": "運算子",
+        "comparison": "比較",
+        "comparisonOps": "=, !=, <, >, <=, >=, ~, !~",
+        "arithmetic": "算術",
+        "arithmeticOps": "+, -, *, /, div, mod",
+        "stringOps": "字串",
+        "stringOpsVal": "+, &, Length(), IndexOf(), Substring()",
+        "dateTimeOps": "日期時間",
+        "dateTimeOpsVal": "+, -, duration in, difference in",
+        "listOps": "列表",
+        "listOpsVal": "in, contains, includes, union, intersect, except",
+        "logical": "邏輯",
+        "logicalOps": "and, or, not, xor, implies"
+      },
+      "retrieve": {
+        "title": "FHIR 資料擷取模式",
+        "pattern": "模式",
+        "basicRetrieve": "基本擷取",
+        "basicRetrieveEx": "[Condition]",
+        "codeFilter": "代碼篩選",
+        "codeFilterEx": "[Condition: \"Diabetes\"]",
+        "dateFilter": "日期篩選",
+        "dateFilterEx": "[Observation] O where O.effective during \"Measurement Period\""
+      },
+      "functions": {
+        "title": "常用函式",
+        "function": "函式",
+        "description": "說明",
+        "ageInYears": "AgeInYears()",
+        "ageInYearsDesc": "評估時病患的年齡（以年為單位）",
+        "count": "Count(list)",
+        "countDesc": "列表中的元素數量",
+        "exists": "exists(list)",
+        "existsDesc": "列表至少有一個元素時為 true",
+        "first": "First(list)",
+        "firstDesc": "列表的第一個元素",
+        "last": "Last(list)",
+        "lastDesc": "列表的最後一個元素",
+        "sum": "Sum(list)",
+        "sumDesc": "數值元素的總和",
+        "avg": "Avg(list)",
+        "avgDesc": "數值元素的平均值",
+        "toString": "ToString(value)",
+        "toStringDesc": "將值轉換為字串表示",
+        "toDateTime": "ToDateTime(value)",
+        "toDateTimeDesc": "將值轉換為日期時間",
+        "flatten": "Flatten(list)",
+        "flattenDesc": "將巢狀列表展平為單一列表"
+      }
+    },
+    "quiz": {
+      "title": "CQL 自我測驗",
+      "subtitle": "測試您對 CQL 核心概念的理解",
+      "question": "第 {{current}} 題（共 {{total}} 題）",
+      "checkAnswer": "確認答案",
+      "next": "下一題",
+      "restart": "重新測驗",
+      "score": "您的得分：{{score}} / {{total}}",
+      "perfect": "滿分！您已掌握 CQL 的核心概念。",
+      "good": "做得不錯！建議再複習一下答錯的部分。",
+      "needsWork": "還需要加油！建議先閱讀入門介紹和核心概念。",
+      "correct": "正確！",
+      "incorrect": "不正確。",
+      "reviewTopics": "需要複習的主題：",
+      "topics": {
+        "terminology": "術語系統",
+        "syntax": "語法",
+        "concepts": "核心概念",
+        "twcore": "TWCORE",
+        "standards": "標準規範"
+      },
       "q1": {
         "question": "CQL 的全稱是什麼？",
         "options": ["Clinical Query Language", "Clinical Quality Language", "Computer Query Language", "Clinical Quantitative Language"],

--- a/frontend/src/pages/LearnPage.tsx
+++ b/frontend/src/pages/LearnPage.tsx
@@ -23,6 +23,9 @@ import {
   RocketLaunch as StartIcon,
   Code as PlaygroundIcon,
   Quiz as QuizIcon,
+  School as AdvancedIcon,
+  BugReport as TroubleshootingIcon,
+  ListAlt as CheatSheetIcon,
 } from '@mui/icons-material'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
@@ -31,11 +34,22 @@ import ConceptGuide from '../components/learn/ConceptGuide'
 import TwcoreGuide from '../components/learn/TwcoreGuide'
 import InteractiveExamples from '../components/learn/InteractiveExamples'
 import QuickStartGuide from '../components/learn/QuickStartGuide'
+import AdvancedTopics from '../components/learn/AdvancedTopics'
+import TroubleshootingGuide from '../components/learn/TroubleshootingGuide'
+import CqlCheatSheet from '../components/learn/CqlCheatSheet'
 import CqlPlayground from '../components/learn/CqlPlayground'
 import CqlQuiz from '../components/learn/CqlQuiz'
 
-const TAB_KEYS = ['introduction', 'concepts', 'twcore', 'examples', 'quickStart', 'playground', 'quiz'] as const
-const TAB_ICONS = [IntroIcon, ConceptIcon, TwcoreIcon, ExampleIcon, StartIcon, PlaygroundIcon, QuizIcon]
+const TAB_KEYS = [
+  'introduction', 'concepts', 'twcore', 'examples', 'quickStart',
+  'advanced', 'troubleshooting', 'cheatSheet',
+  'playground', 'quiz',
+] as const
+const TAB_ICONS = [
+  IntroIcon, ConceptIcon, TwcoreIcon, ExampleIcon, StartIcon,
+  AdvancedIcon, TroubleshootingIcon, CheatSheetIcon,
+  PlaygroundIcon, QuizIcon,
+]
 
 export default function LearnPage() {
   const { t, i18n } = useTranslation('landing')
@@ -111,7 +125,7 @@ export default function LearnPage() {
           <Tabs
             value={currentTab}
             onChange={handleTabChange}
-            variant={isMobile ? 'scrollable' : 'standard'}
+            variant={isMobile ? 'scrollable' : 'scrollable'}
             scrollButtons="auto"
             sx={{
               '& .MuiTab-root': { textTransform: 'none', fontWeight: 600, minHeight: 52 },
@@ -140,8 +154,11 @@ export default function LearnPage() {
           {currentTab === 2 && <TwcoreGuide />}
           {currentTab === 3 && <InteractiveExamples />}
           {currentTab === 4 && <QuickStartGuide />}
-          {currentTab === 5 && <CqlPlayground />}
-          {currentTab === 6 && <CqlQuiz />}
+          {currentTab === 5 && <AdvancedTopics />}
+          {currentTab === 6 && <TroubleshootingGuide />}
+          {currentTab === 7 && <CqlCheatSheet />}
+          {currentTab === 8 && <CqlPlayground />}
+          {currentTab === 9 && <CqlQuiz />}
         </Container>
       </Box>
 


### PR DESCRIPTION
## 變更說明

CQL 學習中心全面優化，8 項改進提升學習體驗：
1. 練習場升級 Monaco Editor（語法高亮）
2. 範例新增「在編輯器中開啟」按鈕
3. 新 Tab：進階主題（聚合、多來源查詢、區間運算、元組）
4. 新 Tab：排錯指南（6 個常見錯誤與解法）
5. 新 Tab：CQL 語法速查表（可折疊手冊）
6. i18n 修復（TwcoreGuide 表頭、Playground 模板標籤）
7. 測驗增強（弱項主題提示 + 連結相關章節）
8. LearnPage 擴充至 10 個 Tab

## 變更類型

- [x] 新功能 (feat)

## 關聯 Issue

Closes #86

## 測試紀錄

- [x] 型別檢查通過 (`npx tsc --noEmit`)

**測試摘要：**
- 3 個新元件 + 5 個修改元件 + i18n 更新
- 1091 行新增，75 行移除

## 風險評估

| 項目 | 說明 |
|------|------|
| 風險等級 | 低 |
| 影響範圍 | 前端 learn/ 元件 + LearnPage + i18n |
| 回歸風險 | 低 — 獨立頁面，不影響核心功能 |

## 安全性確認

- [x] 此變更不涉及安全性等級 B/C 的功能
- [x] 無硬編碼敏感資訊

## IEC 62304 / ISO 14971 追溯

| 法規項目 | 關聯 Issue |
|----------|-----------|
| 軟體需求 | #86 |
| 軟體設計 | N/A — 安全性等級 A |
| 風險分析 | N/A — 安全性等級 A |
| 驗證紀錄 | N/A — 安全性等級 A |

🤖 Generated with [Claude Code](https://claude.com/claude-code)