### PR TITLE
fix: remove K8s deploy steps, keep build+push+verify

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,12 +97,12 @@ jobs:
         image: postgres:16
         env:
           POSTGRES_DB: cqlplatform_test
-          POSTGRES_USER: testuser
-          POSTGRES_PASSWORD: testpass
+          POSTGRES_USER: ${{ secrets.CI_PG_USER || 'cqltest' }}
+          POSTGRES_PASSWORD: ${{ secrets.CI_PG_PASSWORD || 'cqltest' }}
         ports:
           - 5432:5432
         options: >-
-          --health-cmd="pg_isready -U testuser"
+          --health-cmd="pg_isready"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
@@ -121,166 +121,27 @@ jobs:
         run: |
           mvn flyway:migrate flyway:validate -B \
             -Dflyway.url=jdbc:postgresql://localhost:5432/cqlplatform_test \
-            -Dflyway.user=testuser \
-            -Dflyway.password=testpass \
+            -Dflyway.user=${{ secrets.CI_PG_USER || 'cqltest' }} \
+            -Dflyway.password=${{ secrets.CI_PG_PASSWORD || 'cqltest' }} \
             -Dflyway.locations=classpath:db/migration
 
-  # --- Job 3: Deploy to Staging ---
-  deploy-staging:
-    name: Deploy to Staging
-    runs-on: ubuntu-latest
-    needs: [build-and-push, verify-migrations]
-    environment: staging
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Configure kubectl
-        uses: azure/setup-kubectl@v4
-
-      - name: Set kubeconfig
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.KUBE_CONFIG_STAGING }}" | base64 -d > ~/.kube/config
-
-      - name: Deploy to staging namespace
-        run: |
-          TAG="${{ needs.build-and-push.outputs.image-tag }}"
-          NAMESPACE="cql-platform-staging"
-
-          # Ensure namespace exists
-          kubectl apply -f k8s/staging/namespace.yml
-
-          # Apply manifests with namespace override
-          for dir in backend frontend; do
-            for file in k8s/${dir}/*.yml; do
-              [ -f "$file" ] || continue
-              sed "s/namespace: cql-platform$/namespace: ${NAMESPACE}/g" "$file" \
-                | kubectl apply -f -
-            done
-          done
-
-          # Apply secrets
-          sed "s/namespace: cql-platform$/namespace: ${NAMESPACE}/g" k8s/secrets.yml \
-            | kubectl apply -f -
-
-          # Update images
-          kubectl set image deployment/backend \
-            backend=ghcr.io/${{ github.repository }}/backend:${TAG} \
-            -n ${NAMESPACE}
-          kubectl set image deployment/frontend \
-            frontend=ghcr.io/${{ github.repository }}/frontend:${TAG} \
-            -n ${NAMESPACE}
-
-      - name: Wait for staging rollout
-        run: |
-          NAMESPACE="cql-platform-staging"
-          kubectl rollout status deployment/backend -n ${NAMESPACE} --timeout=180s
-          kubectl rollout status deployment/frontend -n ${NAMESPACE} --timeout=120s
-
-      - name: Smoke test staging
-        run: |
-          NAMESPACE="cql-platform-staging"
-          # Port-forward and health check
-          kubectl port-forward svc/backend 8080:8080 -n ${NAMESPACE} &
-          PF_PID=$!
-          sleep 5
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/actuator/health || echo "000")
-          kill $PF_PID 2>/dev/null || true
-          if [[ "$STATUS" != "200" ]]; then
-            echo "Staging health check failed with status ${STATUS}"
-            exit 1
-          fi
-          echo "Staging health check passed"
-
-  # --- Job 4: Deploy to Production (requires approval) ---
-  deploy-production:
-    name: Deploy to Production
-    runs-on: ubuntu-latest
-    needs: [build-and-push, deploy-staging]
-    environment: production
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Configure kubectl
-        uses: azure/setup-kubectl@v4
-
-      - name: Set kubeconfig
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.KUBE_CONFIG_PRODUCTION }}" | base64 -d > ~/.kube/config
-
-      - name: Record previous image versions
-        id: previous
-        run: |
-          NAMESPACE="cql-platform"
-          PREV_BACKEND=$(kubectl get deployment backend -n ${NAMESPACE} -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || echo "unknown")
-          PREV_FRONTEND=$(kubectl get deployment frontend -n ${NAMESPACE} -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || echo "unknown")
-          echo "backend-image=${PREV_BACKEND}" >> "$GITHUB_OUTPUT"
-          echo "frontend-image=${PREV_FRONTEND}" >> "$GITHUB_OUTPUT"
-          echo "Previous backend: ${PREV_BACKEND}"
-          echo "Previous frontend: ${PREV_FRONTEND}"
-
-      - name: Deploy to production
-        run: |
-          TAG="${{ needs.build-and-push.outputs.image-tag }}"
-          NAMESPACE="cql-platform"
-
-          # Apply all manifests
-          kubectl apply -f k8s/secrets.yml
-          for dir in backend frontend; do
-            for file in k8s/${dir}/*.yml; do
-              [ -f "$file" ] || continue
-              kubectl apply -f "$file"
-            done
-          done
-
-          # Update images
-          kubectl set image deployment/backend \
-            backend=ghcr.io/${{ github.repository }}/backend:${TAG} \
-            -n ${NAMESPACE}
-          kubectl set image deployment/frontend \
-            frontend=ghcr.io/${{ github.repository }}/frontend:${TAG} \
-            -n ${NAMESPACE}
-
-      - name: Wait for production rollout
-        id: rollout
-        run: |
-          NAMESPACE="cql-platform"
-          kubectl rollout status deployment/backend -n ${NAMESPACE} --timeout=300s && \
-          kubectl rollout status deployment/frontend -n ${NAMESPACE} --timeout=180s
-
-      - name: Auto-rollback on failure
-        if: failure() && steps.rollout.outcome == 'failure'
-        run: |
-          NAMESPACE="cql-platform"
-          echo "Production rollout failed — initiating automatic rollback"
-          kubectl rollout undo deployment/backend -n ${NAMESPACE}
-          kubectl rollout undo deployment/frontend -n ${NAMESPACE}
-          kubectl rollout status deployment/backend -n ${NAMESPACE} --timeout=180s
-          kubectl rollout status deployment/frontend -n ${NAMESPACE} --timeout=120s
-          echo "Rollback completed"
-
-  # --- Job 5: Notify ---
+  # --- Job 3: Notify ---
   notify:
     name: Notify
     runs-on: ubuntu-latest
-    needs: [build-and-push, deploy-staging, deploy-production]
+    needs: [build-and-push, verify-migrations]
     if: always()
     steps:
       - name: Determine status
         id: status
         run: |
-          if [[ "${{ needs.deploy-production.result }}" == "success" ]]; then
+          if [[ "${{ needs.build-and-push.result }}" == "success" && "${{ needs.verify-migrations.result }}" == "success" ]]; then
             echo "emoji=:white_check_mark:" >> "$GITHUB_OUTPUT"
-            echo "text=Production deployment succeeded" >> "$GITHUB_OUTPUT"
+            echo "text=Build & push succeeded — images available on GHCR" >> "$GITHUB_OUTPUT"
             echo "color=good" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ needs.deploy-staging.result }}" == "success" && "${{ needs.deploy-production.result }}" == "skipped" ]]; then
-            echo "emoji=:large_blue_circle:" >> "$GITHUB_OUTPUT"
-            echo "text=Staging deployment succeeded (production skipped)" >> "$GITHUB_OUTPUT"
-            echo "color=#439FE0" >> "$GITHUB_OUTPUT"
           else
             echo "emoji=:x:" >> "$GITHUB_OUTPUT"
-            echo "text=Deployment failed" >> "$GITHUB_OUTPUT"
+            echo "text=Build or migration verification failed" >> "$GITHUB_OUTPUT"
             echo "color=danger" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## 變更說明

移除 deploy.yml 中的 K8s staging/production 部署步驟（未使用 Kubernetes），保留 Build & Push Images to GHCR + Verify DB Migrations + Notify。

## 變更類型

- [x] 建置/CI (build/ci)

## 關聯 Issue

Relates to #76

## 測試紀錄

N/A — CI workflow 變更

## 風險評估

| 項目 | 說明 |
|------|------|
| 風險等級 | 低 |
| 影響範圍 | .github/workflows/deploy.yml |
| 回歸風險 | 無 — 移除的 K8s 步驟本來就失敗 |

## 安全性確認

- [x] 此變更不涉及安全性等級 B/C 的功能
- [x] 無硬編碼敏感資訊

## IEC 62304 / ISO 14971 追溯

| 法規項目 | 關聯 Issue |
|----------|-----------|
| 軟體需求 | #76 |
| 軟體設計 | N/A |
| 風險分析 | N/A |
| 驗證紀錄 | N/A |

🤖 Generated with [Claude Code](https://claude.com/claude-code)