### PR TITLE
docs: add commit hash to CHANGE_LOG #PAT-057

### DIFF
--- a/docs/CHANGE_LOG.md
+++ b/docs/CHANGE_LOG.md
@@ -9,6 +9,8 @@
 
 | ID | 類型 | 日期 | 範圍 | 標題 | 備註 | Commit |
 |-----|------|------|------|------|------|--------|
+| PAT-057 | ✨ feature | 2026-03-15 | 前端（學習中心） | CQL 學習中心全面優化 — Monaco 練習場 + 「在編輯器中開啟」按鈕 + 進階主題/排錯指南/速查表 3 新 Tab + 測驗弱項提示 + i18n 修復 + 速查表擴充（基本結構 12 項 + 資料存取 13 項）| 10 Tab、+1292 行 | [`3edac7b`](../../commit/3edac7b) [`acd9136`](../../commit/acd9136) |
+| BUG-093 | 🔧 refactor | 2026-03-15 | CI/CD（Deploy） | 移除 K8s 部署步驟 — 保留 Build+Push GHCR + Verify Migrations + Notify，修復 Deploy workflow 失敗 | -149 行 | [`6af3f31`](../../commit/6af3f31) |
 | BUG-092 | 🔒 security | 2026-03-14 | 後端（依賴安全） | Jackson CVE 修復 — jackson-bom 2.21.1 (GHSA-72hv-8253-57qq) + tools.jackson 3.1.0 (CVE-2026-29062) — Security Scan 全綠 | logstash-logback-encoder 傳遞依賴 | [`ca9ebf7`](../../commit/ca9ebf7) |
 | PAT-056 | ✨ feature | 2026-03-14 | 前端（品質指標） | eCQM CQL Tab 從程式庫匯入 — 新增 ImportCqlFromLibraryDialog（搜尋/選擇/確認覆蓋）+ MeasureCqlTab 匯入按鈕，複用現有 CQL Libraries API | i18n EN+zh-TW | [`9a96f5f`](../../commit/9a96f5f) |
 | PAT-055 | ✨ feature | 2026-03-14 | 後端（CQL Engine） | CQL Framework 3.29→4.5.0 升級 — Kotlin Multiplatform 架構、groupId 遷移 (info→org.cqframework)、LibrarySourceProvider kotlinx.io.Source 適配、EvaluationParams builder、RestFhirRetrieveProvider +ModelResolver | 821 tests pass、6 檔案修改 | [`0d0f28a`](../../commit/0d0f28a) |


### PR DESCRIPTION
## 變更說明

更新 CHANGE_LOG.md，新增 PAT-057（學習中心優化）和 BUG-093（移除 K8s 部署）記錄。

## 變更類型

- [x] 文件更新 (docs)

## 關聯 Issue

Relates to #86

## 風險評估

| 項目 | 說明 |
|------|------|
| 風險等級 | 低 |
| 影響範圍 | docs/CHANGE_LOG.md |
| 回歸風險 | 無 |

## 安全性確認

- [x] 此變更不涉及安全性等級 B/C 的功能

## IEC 62304 / ISO 14971 追溯

| 法規項目 | 關聯 Issue |
|----------|-----------|
| 軟體需求 | #86 |
| 軟體設計 | N/A |
| 風險分析 | N/A |
| 驗證紀錄 | N/A |