### PR TITLE
fix: add missing Grid container prop for MUI v7 compatibility (#BUG-094)

### DIFF
--- a/frontend/src/components/common/DashboardSkeleton.tsx
+++ b/frontend/src/components/common/DashboardSkeleton.tsx
@@ -5,7 +5,7 @@ export default function DashboardSkeleton() {
     <Box sx={{ p: 3 }}>
       <Stack spacing={3}>
         {/* Stat cards row */}
-        <Grid spacing={2}>
+        <Grid container spacing={2}>
           {Array.from({ length: 4 }).map((_, i) => (
             <Grid size={{ xs: 6, md: 3 }} key={i}>
               <Skeleton variant="rounded" height={100} />
@@ -14,7 +14,7 @@ export default function DashboardSkeleton() {
         </Grid>
 
         {/* Chart areas */}
-        <Grid spacing={2}>
+        <Grid container spacing={2}>
           <Grid size={{ xs: 12, md: 8 }}>
             <Skeleton variant="rounded" height={300} />
           </Grid>

--- a/frontend/src/components/landing/CqlShowcase.tsx
+++ b/frontend/src/components/landing/CqlShowcase.tsx
@@ -21,7 +21,7 @@ export default function CqlShowcase() {
         {t('showcase.subtitle')}
       </Typography>
 
-      <Grid spacing={4} sx={{ maxWidth: 1100, mx: 'auto' }}>
+      <Grid container spacing={4} sx={{ maxWidth: 1100, mx: 'auto' }}>
         {/* CQL Code */}
         <Grid size={{ xs: 12, md: 7 }}>
           <Paper

--- a/frontend/src/components/landing/FeatureCards.tsx
+++ b/frontend/src/components/landing/FeatureCards.tsx
@@ -25,7 +25,7 @@ export default function FeatureCards() {
       <Typography variant="body1" textAlign="center" color="text.secondary" sx={{ mb: 5, maxWidth: 600, mx: 'auto' }}>
         {t('features.subtitle')}
       </Typography>
-      <Grid spacing={3} justifyContent="center" sx={{ maxWidth: 1100, mx: 'auto' }}>
+      <Grid container spacing={3} justifyContent="center" sx={{ maxWidth: 1100, mx: 'auto' }}>
         {FEATURES.map(({ key, icon: Icon, color }) => (
           <Grid size={{ xs: 12, sm: 6, md: 3 }} key={key}>
             <Paper

--- a/frontend/src/components/learn/AdvancedTopics.tsx
+++ b/frontend/src/components/learn/AdvancedTopics.tsx
@@ -126,7 +126,7 @@ export default function AdvancedTopics() {
         {t('learn.advanced.subtitle')}
       </Typography>
 
-      <Grid spacing={3}>
+      <Grid container spacing={3}>
         {TOPICS.map(({ key, code }) => (
           <Grid key={key} size={12}>
             <Paper elevation={0} sx={{ p: 3, borderRadius: 3, border: '1px solid', borderColor: 'divider' }}>

--- a/frontend/src/components/learn/ConceptGuide.tsx
+++ b/frontend/src/components/learn/ConceptGuide.tsx
@@ -28,7 +28,7 @@ export default function ConceptGuide() {
         {t('learn.concepts.title')}
       </Typography>
 
-      <Grid spacing={3} sx={{ mt: 1 }}>
+      <Grid container spacing={3} sx={{ mt: 1 }}>
         {CONCEPTS.map(({ key, code }, index) => (
           <Grid size={{ xs: 12, md: 6 }} key={key}>
             <Paper

--- a/frontend/src/components/learn/CqlIntroduction.tsx
+++ b/frontend/src/components/learn/CqlIntroduction.tsx
@@ -16,7 +16,7 @@ export default function CqlIntroduction() {
         {t('learn.introduction.title')}
       </Typography>
 
-      <Grid spacing={3} sx={{ mt: 1 }}>
+      <Grid container spacing={3} sx={{ mt: 1 }}>
         {/* What is CQL */}
         <Grid size={12}>
           <Paper elevation={0} sx={{ p: 3, borderRadius: 3, border: '1px solid', borderColor: 'divider' }}>
@@ -85,7 +85,7 @@ export default function CqlIntroduction() {
               <AppIcon sx={{ mr: 1, verticalAlign: 'middle', fontSize: 22 }} />
               {t('learn.introduction.applications.title')}
             </Typography>
-            <Grid spacing={2} sx={{ mt: 0.5 }}>
+            <Grid container spacing={2} sx={{ mt: 0.5 }}>
               {(['ecqm', 'cds', 'phenotyping', 'research'] as const).map((key) => (
                 <Grid size={{ xs: 12, sm: 6 }} key={key}>
                   <Box

--- a/frontend/src/components/learn/CqlPlayground.tsx
+++ b/frontend/src/components/learn/CqlPlayground.tsx
@@ -80,7 +80,7 @@ export default function CqlPlayground() {
         {t('learn.playground.subtitle')}
       </Typography>
 
-      <Grid spacing={3}>
+      <Grid container spacing={3}>
         <Grid size={12}>
           <Paper elevation={0} sx={{ borderRadius: 3, border: '1px solid', borderColor: 'divider', overflow: 'hidden' }}>
             {/* Toolbar */}

--- a/frontend/src/components/learn/InteractiveExamples.tsx
+++ b/frontend/src/components/learn/InteractiveExamples.tsx
@@ -52,7 +52,7 @@ export default function InteractiveExamples() {
         {t('learn.examples.subtitle')}
       </Typography>
 
-      <Grid spacing={3}>
+      <Grid container spacing={3}>
         {/* Example List */}
         <Grid size={{ xs: 12, md: 4 }}>
           <Paper elevation={0} sx={{ borderRadius: 3, border: '1px solid', borderColor: 'divider', overflow: 'hidden' }}>

--- a/frontend/src/components/learn/TroubleshootingGuide.tsx
+++ b/frontend/src/components/learn/TroubleshootingGuide.tsx
@@ -110,7 +110,7 @@ export default function TroubleshootingGuide() {
         {t('learn.troubleshooting.subtitle')}
       </Typography>
 
-      <Grid spacing={3}>
+      <Grid container spacing={3}>
         {ERROR_KEYS.map((key) => (
           <Grid key={key} size={12}>
             <Paper elevation={0} sx={{ p: 3, borderRadius: 3, border: '1px solid', borderColor: 'divider' }}>

--- a/frontend/src/components/learn/TwcoreGuide.tsx
+++ b/frontend/src/components/learn/TwcoreGuide.tsx
@@ -29,7 +29,7 @@ export default function TwcoreGuide() {
         {t('learn.twcore.title')}
       </Typography>
 
-      <Grid spacing={3} sx={{ mt: 1 }}>
+      <Grid container spacing={3} sx={{ mt: 1 }}>
         {/* Overview */}
         <Grid size={12}>
           <Paper elevation={0} sx={{ p: 3, borderRadius: 3, border: '1px solid', borderColor: 'divider' }}>

--- a/frontend/src/components/measure/PopulationCriteriaTab.tsx
+++ b/frontend/src/components/measure/PopulationCriteriaTab.tsx
@@ -748,7 +748,7 @@ export default function PopulationCriteriaTab({ measure, onMeasureUpdate, readOn
                   ))}
                 </TextField>
 
-                <Grid spacing={2}>
+                <Grid container spacing={2}>
                   {/* Left column: standard populations */}
                   <Grid size={{ xs: 12, md: hasExclusions ? 6 : 12 }}>
                     <Typography variant="subtitle2" color="text.secondary" gutterBottom>

--- a/frontend/src/pages/CdsPage.tsx
+++ b/frontend/src/pages/CdsPage.tsx
@@ -27,7 +27,7 @@ export default function CdsPage() {
         </Typography>
       </Box>
 
-      <Grid spacing={2} sx={{ height: 'calc(100% - 90px)' }}>
+      <Grid container spacing={2} sx={{ height: 'calc(100% - 90px)' }}>
         <Grid size={{ xs: 12, md: 6 }}>
           <CqlEditor height="100%" />
         </Grid>

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -306,7 +306,7 @@ export default function EditorPage() {
         accept=".json,.cql"
         style={{ display: 'none' }}
       />
-      <Grid spacing={2} sx={{ height: '100%' }}>
+      <Grid container spacing={2} sx={{ height: '100%' }}>
         <Grid size={{ xs: 12, md: 2 }} sx={{ height: '100%', display: { xs: 'none', md: 'block' } }}>
           <LibraryQuickAccess />
         </Grid>

--- a/frontend/src/pages/MeasureDashboardPage.tsx
+++ b/frontend/src/pages/MeasureDashboardPage.tsx
@@ -83,7 +83,7 @@ function OverviewCards({ data }: { data: DashboardSummary }) {
   ]
 
   return (
-    <Grid spacing={2}>
+    <Grid container spacing={2}>
       {cards.map((card) => (
         <Grid size={{ xs: 12, sm: 6, md: 'grow' }} key={card.label}>
           <Paper
@@ -297,7 +297,7 @@ export default function MeasureDashboardPage() {
       />
 
       {/* Overview cards + Alerts */}
-      <Grid spacing={3} sx={{ mb: 3 }}>
+      <Grid container spacing={3} sx={{ mb: 3 }}>
         <Grid size={{ xs: 12, md: 9 }}>
           <OverviewCards data={data} />
         </Grid>
@@ -314,7 +314,7 @@ export default function MeasureDashboardPage() {
       )}
 
       {/* Department drill-down + Score distribution */}
-      <Grid spacing={3} sx={{ mb: 3 }}>
+      <Grid container spacing={3} sx={{ mb: 3 }}>
         <Grid size={{ xs: 12, md: 6 }}>
           {enhancedData?.departmentScores && Object.keys(enhancedData.departmentScores).length > 0 ? (
             <DepartmentDrilldownChart data={enhancedData.departmentScores} />
@@ -330,7 +330,7 @@ export default function MeasureDashboardPage() {
       </Grid>
 
       {/* Recent evaluations + Quality report */}
-      <Grid spacing={3}>
+      <Grid container spacing={3}>
         <Grid size={{ xs: 12, md: 7 }}>
           <RecentEvaluationsTable evaluations={data.recentEvaluations} />
         </Grid>

--- a/frontend/src/pages/MeasuresPage.tsx
+++ b/frontend/src/pages/MeasuresPage.tsx
@@ -65,7 +65,7 @@ export default function MeasuresPage() {
         )}
 
         {topTab === 1 && (
-          <Grid spacing={2} sx={{ height: '100%' }}>
+          <Grid container spacing={2} sx={{ height: '100%' }}>
             {/* Left panel: Measure Library */}
             <Grid size={{ xs: 12, md: selectedMeasure ? 4 : 12 }} sx={{ height: '100%' }}>
               <MeasureLibrary onSelectMeasure={handleSelectMeasure} />


### PR DESCRIPTION
## 變更說明

Dependabot 將 MUI 從 v5 升級至 v7，MUI v7 的 Grid 需要顯式 `container` prop 才能啟用 flex 容器行為。缺少此 prop 導致所有頁面的 Grid 子元素垂直堆疊，版面完全跑掉。

修復 15 個檔案：`<Grid spacing=` → `<Grid container spacing=`

## 變更類型

- [x] 錯誤修復 (fix)

## 關聯 Issue

Closes #92

## 測試紀錄

- [x] 型別檢查通過 (`npx tsc --noEmit`)
- [x] Docker 重建後版面恢復正常

## 風險評估

| 項目 | 說明 |
|------|------|
| 風險等級 | 低 |
| 影響範圍 | 15 個前端檔案 |
| 回歸風險 | 無 |

## 安全性確認

- [x] 此變更不涉及安全性等級 B/C 的功能

## IEC 62304 / ISO 14971 追溯

| 法規項目 | 關聯 Issue |
|----------|-----------|
| 軟體需求 | #92 |
| 軟體設計 | N/A — 安全性等級 A |
| 風險分析 | N/A — 安全性等級 A |
| 驗證紀錄 | N/A — 安全性等級 A |

🤖 Generated with [Claude Code](https://claude.com/claude-code)