### PR TITLE
fix: resolve CSP violation for Cloudflare beacon and remove direct FHIR fetch (#BUG-096)

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -14,7 +14,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net; worker-src 'self' blob:; connect-src 'self' https://cdn.jsdelivr.net http://localhost:8090 http://hapi-fhir:8080; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net; worker-src 'self' blob:; connect-src 'self' https://cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 

--- a/frontend/src/components/patient-generator/GenerationResultPanel.tsx
+++ b/frontend/src/components/patient-generator/GenerationResultPanel.tsx
@@ -10,7 +10,6 @@ import {
   AccordionSummary,
   AccordionDetails,
   Chip,
-  TextField,
   CircularProgress,
   IconButton,
   Tooltip,
@@ -24,6 +23,7 @@ import {
 } from '@mui/icons-material'
 import { useTranslation } from 'react-i18next'
 import { useCopyToClipboard } from '../../hooks/useCopyToClipboard'
+import { fhirApi } from '../../api/fhirApi'
 import type { GeneratedPatientData } from '../../config/twcore'
 
 interface GenerationResultPanelProps {
@@ -39,7 +39,6 @@ export default function GenerationResultPanel({
 }: GenerationResultPanelProps) {
   const { t } = useTranslation('patientGenerator')
   const copyToClipboard = useCopyToClipboard()
-  const [serverUrl, setServerUrl] = useState('http://localhost:8090/fhir')
   const [uploading, setUploading] = useState(false)
   const [uploadMessage, setUploadMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
 
@@ -57,7 +56,6 @@ export default function GenerationResultPanel({
   }, [results])
 
   const handleUpload = useCallback(async () => {
-    if (!serverUrl.trim()) return
     setUploading(true)
     setUploadMessage(null)
     let uploadedCount = 0
@@ -74,12 +72,11 @@ export default function GenerationResultPanel({
           ...patientData.allergies,
         ]
         for (const resource of allResources) {
-          const response = await fetch(`${serverUrl}/${resource.resourceType}`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/fhir+json' },
-            body: JSON.stringify(resource),
-          })
-          if (response.ok) uploadedCount++
+          await fhirApi.createResource(
+            resource.resourceType as string,
+            JSON.stringify(resource),
+          )
+          uploadedCount++
         }
       }
       setUploadMessage({ type: 'success', text: t('result.uploadSuccess', { count: uploadedCount }) })
@@ -91,7 +88,7 @@ export default function GenerationResultPanel({
     } finally {
       setUploading(false)
     }
-  }, [serverUrl, results, t])
+  }, [results, t])
 
   if (results.length === 0) return null
 
@@ -123,18 +120,11 @@ export default function GenerationResultPanel({
       </Stack>
 
       <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
-        <TextField
-          size="small"
-          label={t('result.serverUrl')}
-          value={serverUrl}
-          onChange={(e) => setServerUrl(e.target.value)}
-          sx={{ flex: 1 }}
-        />
         <Button
           variant="outlined"
           startIcon={uploading ? <CircularProgress size={18} /> : <UploadIcon />}
           onClick={handleUpload}
-          disabled={uploading || !serverUrl.trim()}
+          disabled={uploading}
         >
           {uploading ? t('result.uploading') : t('result.uploadToServer')}
         </Button>


### PR DESCRIPTION
## 變更說明

修復 www.twcql.com 上的三個 console 錯誤：

1. **CSP 阻擋 Cloudflare beacon** — `script-src` 新增 `https://static.cloudflareinsights.com`
2. **移除過時的 CSP connect-src** — 刪除 `http://localhost:8090` 和 `http://hapi-fhir:8080`（瀏覽器無法直連 Docker 內部網路或 localhost）
3. **假病人上傳改用 API proxy** — `GenerationResultPanel` 從直接 `fetch()` 改為 `fhirApi.createResource()`，透過後端 proxy 上傳 FHIR 資源

## 關聯 Issue

- #117

## 測試紀錄

- [x] `npx tsc --noEmit` 通過
- [x] CSP header 正確包含 Cloudflare beacon domain
- [x] GenerationResultPanel 不再引用 localhost:8090

## 風險評估

低風險 — 修正 CSP header 和替換前端直連為 API proxy

### IEC 62304 追溯

| 類別 | 項目 |
|------|------|
| 安全性等級 | A |
| 需求 | #117 |
| 設計 | N/A |
| 風險 | N/A |

🤖 Generated with [Claude Code](https://claude.com/claude-code)