### PR TITLE
fix: use Axios client for SSE ticket request to enable silent JWT refresh

### DIFF
--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useEffect, useRef, useCallback } from 'react'
+import { api } from '../api/client'
 import { notificationApi } from '../api/notificationApi'
 import { STALE_30S, REFETCH_30S } from '../constants/queryConstants'
 
@@ -53,17 +54,11 @@ export function useNotifications() {
 
     const baseUrl = import.meta.env.VITE_API_URL || '/api'
 
-    // Obtain a short-lived, single-use ticket to avoid exposing the
-    // long-lived JWT in a query parameter (leaks into logs/history)
-    fetch(`${baseUrl}/auth/sse-ticket`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-    })
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error('ticket request failed'))))
-      .then(({ ticket }: { ticket: string }) => {
+    // Use the Axios client so expired JWTs are silently refreshed via
+    // the response interceptor before we attempt to open the EventSource.
+    api
+      .post<{ ticket: string }>('/auth/sse-ticket')
+      .then(({ data: { ticket } }) => {
         const url = `${baseUrl}/notifications/subscribe?ticket=${encodeURIComponent(ticket)}`
         const es = new EventSource(url)
         eventSourceRef.current = es
@@ -89,7 +84,7 @@ export function useNotifications() {
       })
       .catch(() => {
         // Ticket request failed or SSE not available — rely on polling
-        setTimeout(connectSSE, 30_000)
+        setTimeout(connectSSE, REFETCH_30S)
       })
   }, [queryClient])
 


### PR DESCRIPTION
## 變更說明

SSE 通知連線使用原生 `fetch()` 呼叫 `/api/auth/sse-ticket`，繞過了 Axios 攔截器的靜默 JWT 刷新機制。當 JWT 過期時，會造成每 30 秒重試一次的無限 401 迴圈。

改為使用 Axios `api` 客戶端，使過期 JWT 能自動刷新後重試。

## 關聯 Issue

- Closes #126

## 測試紀錄

- [x] `npx tsc --noEmit` 型別檢查通過
- [x] 確認 Docker 後端日誌中 SSE ticket 401 錯誤來源
- [x] 確認 nginx 日誌顯示重複 401 回應

## 風險評估

- 風險等級：低
- 影響範圍：僅 SSE 通知連線的認證流程
- 回退方式：還原為原生 `fetch()` 呼叫

## IEC 62304 / ISO 14971 追溯

| 項目 | 內容 |
|------|------|
| 變更類型 | 缺陷修復 |
| 安全性等級 | A（通知功能，非臨床關鍵） |
| 需求追溯 | #126 |
| 風險追溯 | N/A |

🤖 Generated with [Claude Code](https://claude.com/claude-code)