### PR TITLE
perf: parallelize measure patient evaluation + cache terminology provider

### DIFF
--- a/backend/src/main/java/com/cqlplatform/service/fhir/FhirTerminologyService.java
+++ b/backend/src/main/java/com/cqlplatform/service/fhir/FhirTerminologyService.java
@@ -80,19 +80,24 @@ public class FhirTerminologyService {
         return new RestTemplate(factory);
     }
 
+    private final java.util.concurrent.ConcurrentHashMap<String, TerminologyProvider> terminologyProviderCache =
+            new java.util.concurrent.ConcurrentHashMap<>();
+
     public TerminologyProvider createTerminologyProvider(String terminologyServerUrl) {
         String serverUrl = terminologyServerUrl != null ? terminologyServerUrl : defaultTerminologyServerUrl;
-        IGenericClient client = fhirContext.newRestfulGenericClient(serverUrl);
-        TerminologyProvider remoteProvider = new R4FhirTerminologyProvider(client);
+        return terminologyProviderCache.computeIfAbsent(serverUrl, url -> {
+            IGenericClient client = fhirContext.newRestfulGenericClient(url);
+            TerminologyProvider remoteProvider = new R4FhirTerminologyProvider(client);
 
-        boolean hasIg = igService != null && igService.isLoaded();
-        boolean hasVsac = vsacService != null;
+            boolean hasIg = igService != null && igService.isLoaded();
+            boolean hasVsac = vsacService != null;
 
-        if (hasIg || hasVsac) {
-            log.debug("Creating terminology provider with local IG={}, VSAC={}", hasIg, hasVsac);
-            return new LocalTerminologyProvider(hasIg ? igService : null, remoteProvider, hasVsac ? vsacService : null);
-        }
-        return remoteProvider;
+            if (hasIg || hasVsac) {
+                log.debug("Creating terminology provider with local IG={}, VSAC={}", hasIg, hasVsac);
+                return new LocalTerminologyProvider(hasIg ? igService : null, remoteProvider, hasVsac ? vsacService : null);
+            }
+            return remoteProvider;
+        });
     }
 
     @Cacheable(value = "valueSets", key = "#valueSetUrl")

--- a/backend/src/main/java/com/cqlplatform/service/measure/MeasureEvaluationService.java
+++ b/backend/src/main/java/com/cqlplatform/service/measure/MeasureEvaluationService.java
@@ -19,6 +19,9 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import com.cqlplatform.model.measure.EvaluationStatusConstants;
 import static com.cqlplatform.model.measure.PopulationTypeConstants.*;
@@ -28,7 +31,6 @@ import static com.cqlplatform.model.measure.PopulationTypeConstants.*;
  * Flow: discover patients → execute CQL → evaluate populations → stratify → score → save.
  */
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class MeasureEvaluationService {
 
@@ -37,6 +39,22 @@ public class MeasureEvaluationService {
     private final PopulationEvaluator populationEvaluator;
     private final StratifierEvaluator stratifierEvaluator;
     private final MeasureScoreCalculator scoreCalculator;
+    private final ExecutorService measureExecutor;
+
+    public MeasureEvaluationService(
+            CqlExecutionService cqlExecutionService,
+            PatientDiscoveryService patientDiscoveryService,
+            PopulationEvaluator populationEvaluator,
+            StratifierEvaluator stratifierEvaluator,
+            MeasureScoreCalculator scoreCalculator,
+            @org.springframework.beans.factory.annotation.Qualifier("cqlExecutionExecutor") ExecutorService measureExecutor) {
+        this.cqlExecutionService = cqlExecutionService;
+        this.patientDiscoveryService = patientDiscoveryService;
+        this.populationEvaluator = populationEvaluator;
+        this.stratifierEvaluator = stratifierEvaluator;
+        this.scoreCalculator = scoreCalculator;
+        this.measureExecutor = measureExecutor;
+    }
 
     @org.springframework.beans.factory.annotation.Autowired(required = false)
     private MeasureReportService measureReportService;
@@ -143,28 +161,51 @@ public class MeasureEvaluationService {
         Map<String, Map<String, Map<String, Integer>>> stratificationData = new HashMap<>();
         List<StratifierDefinition> stratifiers = stratifierEvaluator.getStratifiers(context.getMeasureDefinition());
 
+        // Execute CQL for all patients in parallel
+        record PatientResult(String patientId, CqlExecutionResponse response, Exception error) {}
+
+        List<CompletableFuture<PatientResult>> futures = patients.stream()
+                .map(patientId -> CompletableFuture.supplyAsync(() -> {
+                    try {
+                        CqlExecutionResponse resp = executeForPatient(context, patientId);
+                        return new PatientResult(patientId, resp, null);
+                    } catch (Exception e) {
+                        return new PatientResult(patientId, null, e);
+                    }
+                }, measureExecutor))
+                .toList();
+
+        // Wait for all patients to finish (with overall timeout)
+        try {
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                    .get(context.getTimeoutSeconds(), TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.warn("Measure evaluation timed out or interrupted after {}s", context.getTimeoutSeconds());
+        }
+
+        // Aggregate results sequentially (thread-safe)
         int errorCount = 0;
-        long deadline = System.currentTimeMillis() + (context.getTimeoutSeconds() * 1000L);
-
-        for (String patientId : patients) {
-            if (System.currentTimeMillis() > deadline) {
-                log.warn("Measure evaluation timed out after {}s", context.getTimeoutSeconds());
-                break;
-            }
-
+        for (CompletableFuture<PatientResult> future : futures) {
+            PatientResult pr;
             try {
-                CqlExecutionResponse execResponse = executeForPatient(context, patientId);
-                Map<String, CqlExecutionResponse.ExpressionResult> results = execResponse.getResults();
-
-                populationEvaluator.aggregatePatientResults(populationCounts, results);
-                populationEvaluator.aggregateCustomExpressions(customExpressions, results, standardNames);
-
-                if (!stratifiers.isEmpty()) {
-                    stratifierEvaluator.evaluatePatientStratifiers(stratifiers, results, stratificationData);
-                }
+                pr = future.getNow(null);
             } catch (Exception e) {
                 errorCount++;
-                log.error("Failed evaluation for patient {}", patientId, e);
+                continue;
+            }
+            if (pr == null || pr.error() != null) {
+                errorCount++;
+                if (pr != null) {
+                    log.error("Failed evaluation for patient {}", pr.patientId(), pr.error());
+                }
+                continue;
+            }
+            Map<String, CqlExecutionResponse.ExpressionResult> results = pr.response().getResults();
+            populationEvaluator.aggregatePatientResults(populationCounts, results);
+            populationEvaluator.aggregateCustomExpressions(customExpressions, results, standardNames);
+
+            if (!stratifiers.isEmpty()) {
+                stratifierEvaluator.evaluatePatientStratifiers(stratifiers, results, stratificationData);
             }
         }
 

--- a/backend/src/test/java/com/cqlplatform/service/measure/MeasureEvaluationServiceTest.java
+++ b/backend/src/test/java/com/cqlplatform/service/measure/MeasureEvaluationServiceTest.java
@@ -45,7 +45,8 @@ class MeasureEvaluationServiceTest {
         stratifierEvaluator = new StratifierEvaluator(populationEvaluator, scoreCalculator);
         measureService = new MeasureEvaluationService(
                 cqlExecutionService, patientDiscoveryService,
-                populationEvaluator, stratifierEvaluator, scoreCalculator);
+                populationEvaluator, stratifierEvaluator, scoreCalculator,
+                java.util.concurrent.Executors.newFixedThreadPool(4));
         ReflectionTestUtils.setField(measureService, "defaultPeriodStart", "");
         ReflectionTestUtils.setField(measureService, "defaultPeriodEnd", "");
         ReflectionTestUtils.setField(measureService, "measureTimeoutSeconds", 120);


### PR DESCRIPTION
## 變更說明

量測評估的病人 CQL 評估原為逐一循序執行（~9s/patient × 11 = ~99s），剛好超過 Cloudflare 的 ~100s 代理逾時，導致 504。

兩項優化：
1. **平行化病人評估**：使用 `CompletableFuture` + 既有 `cqlExecutionExecutor` 執行緒池（10 core / 20 max），所有病人同時評估後再循序彙總
2. **快取 TerminologyProvider**：以 server URL 為 key 的 `ConcurrentHashMap` 快取，避免每位病人重複建立 FHIR 客戶端

## 關聯 Issue

- Closes #127

## 測試紀錄

- [x] MeasureEvaluationServiceTest: 9/9 通過
- [x] 全後端測試套件通過（0 failures）
- [x] 編譯無錯誤

## 風險評估

- 風險等級：低
- 影響範圍：MeasureEvaluationService 的病人迴圈、FhirTerminologyService 的 provider 建立
- 回退方式：還原為循序迴圈

## IEC 62304 / ISO 14971 追溯

| 項目 | 內容 |
|------|------|
| 變更類型 | 效能優化 |
| 安全性等級 | A |
| 需求追溯 | #127 |
| 風險追溯 | N/A |

🤖 Generated with [Claude Code](https://claude.com/claude-code)