### PR TITLE
fix: use ForkJoinPool for outer parallel loop to avoid deadlock

### DIFF
--- a/backend/src/main/java/com/cqlplatform/service/measure/MeasureEvaluationService.java
+++ b/backend/src/main/java/com/cqlplatform/service/measure/MeasureEvaluationService.java
@@ -20,7 +20,6 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import com.cqlplatform.model.measure.EvaluationStatusConstants;
@@ -39,21 +38,18 @@ public class MeasureEvaluationService {
     private final PopulationEvaluator populationEvaluator;
     private final StratifierEvaluator stratifierEvaluator;
     private final MeasureScoreCalculator scoreCalculator;
-    private final ExecutorService measureExecutor;
 
     public MeasureEvaluationService(
             CqlExecutionService cqlExecutionService,
             PatientDiscoveryService patientDiscoveryService,
             PopulationEvaluator populationEvaluator,
             StratifierEvaluator stratifierEvaluator,
-            MeasureScoreCalculator scoreCalculator,
-            @org.springframework.beans.factory.annotation.Qualifier("cqlExecutionExecutor") ExecutorService measureExecutor) {
+            MeasureScoreCalculator scoreCalculator) {
         this.cqlExecutionService = cqlExecutionService;
         this.patientDiscoveryService = patientDiscoveryService;
         this.populationEvaluator = populationEvaluator;
         this.stratifierEvaluator = stratifierEvaluator;
         this.scoreCalculator = scoreCalculator;
-        this.measureExecutor = measureExecutor;
     }
 
     @org.springframework.beans.factory.annotation.Autowired(required = false)
@@ -161,7 +157,9 @@ public class MeasureEvaluationService {
         Map<String, Map<String, Map<String, Integer>>> stratificationData = new HashMap<>();
         List<StratifierDefinition> stratifiers = stratifierEvaluator.getStratifiers(context.getMeasureDefinition());
 
-        // Execute CQL for all patients in parallel
+        // Execute CQL for all patients in parallel.
+        // Use ForkJoinPool (default) for the outer loop — each task delegates to
+        // cqlExecutionExecutor internally, so using the same pool here would deadlock.
         record PatientResult(String patientId, CqlExecutionResponse response, Exception error) {}
 
         List<CompletableFuture<PatientResult>> futures = patients.stream()
@@ -172,7 +170,7 @@ public class MeasureEvaluationService {
                     } catch (Exception e) {
                         return new PatientResult(patientId, null, e);
                     }
-                }, measureExecutor))
+                }))
                 .toList();
 
         // Wait for all patients to finish (with overall timeout)

--- a/backend/src/test/java/com/cqlplatform/service/measure/MeasureEvaluationServiceTest.java
+++ b/backend/src/test/java/com/cqlplatform/service/measure/MeasureEvaluationServiceTest.java
@@ -45,8 +45,7 @@ class MeasureEvaluationServiceTest {
         stratifierEvaluator = new StratifierEvaluator(populationEvaluator, scoreCalculator);
         measureService = new MeasureEvaluationService(
                 cqlExecutionService, patientDiscoveryService,
-                populationEvaluator, stratifierEvaluator, scoreCalculator,
-                java.util.concurrent.Executors.newFixedThreadPool(4));
+                populationEvaluator, stratifierEvaluator, scoreCalculator);
         ReflectionTestUtils.setField(measureService, "defaultPeriodStart", "");
         ReflectionTestUtils.setField(measureService, "defaultPeriodEnd", "");
         ReflectionTestUtils.setField(measureService, "measureTimeoutSeconds", 120);


### PR DESCRIPTION
## 變更說明

修復 #128 引入的執行緒池死鎖問題。外部平行迴圈和內部 CQL 執行都使用同一個 `cqlExecutionExecutor`，導致外部任務佔滿所有執行緒後等待內部任務完成，而內部任務無法取得執行緒 — 死鎖。

改為外部迴圈使用 `ForkJoinPool.commonPool()`（`CompletableFuture` 預設），內部 CQL 執行繼續使用 `cqlExecutionExecutor`。

## 關聯 Issue

- #127

## 測試紀錄

- [x] MeasureEvaluationServiceTest: 9/9 通過

## 風險評估

- 風險等級：低
- 影響範圍：MeasureEvaluationService 的平行化機制

## IEC 62304 / ISO 14971 追溯

| 項目 | 內容 |
|------|------|
| 變更類型 | 缺陷修復 |
| 安全性等級 | A |
| 需求追溯 | #127 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)