### PR TITLE
fix: scenario template patient count + comparison measure autocomplete

### DIFF
--- a/frontend/src/components/measure/MeasureComparison.tsx
+++ b/frontend/src/components/measure/MeasureComparison.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { getScoreThemeColor } from '../../utils/scoreColors'
 import { extractApiError } from '../../utils/errorUtils'
 import {
+  Autocomplete,
   Box,
   Paper,
   Typography,
@@ -23,7 +24,7 @@ import {
   Timeline as TimelineIcon,
 } from '@mui/icons-material'
 import GradientButton from '../common/GradientButton'
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { measureApi } from '../../api'
 import type { MeasureComparisonResult, MeasureTrendResult } from '../../types'
 import { getDefaultComparisonPeriods } from '../../utils/dateDefaults'
@@ -31,6 +32,14 @@ import { getDefaultComparisonPeriods } from '../../utils/dateDefaults'
 export default function MeasureComparison() {
   const { t } = useTranslation('measures')
   const [measureName, setMeasureName] = useState('')
+
+  const { data: measures = [] } = useQuery({
+    queryKey: ['measures'],
+    queryFn: () => measureApi.getMeasures(),
+    staleTime: Infinity,
+  })
+  const measureOptions = measures.map((m) => m.title || m.name)
+
   const defaults = getDefaultComparisonPeriods()
   const [p1Start, setP1Start] = useState(defaults.period1Start)
   const [p1End, setP1End] = useState(defaults.period1End)
@@ -67,12 +76,15 @@ export default function MeasureComparison() {
     <Paper sx={{ p: 2, height: '100%', overflow: 'auto' }}>
       <Typography variant="h6" gutterBottom>{t('comparison.title')}</Typography>
 
-      <TextField
-        label={t('comparison.measureName')}
-        size="small"
-        fullWidth
+      <Autocomplete
+        freeSolo
+        options={measureOptions}
         value={measureName}
-        onChange={(e) => setMeasureName(e.target.value)}
+        onChange={(_e, value) => setMeasureName(value ?? '')}
+        onInputChange={(_e, value) => setMeasureName(value)}
+        renderInput={(params) => (
+          <TextField {...params} label={t('comparison.measureName')} size="small" />
+        )}
         sx={{ mb: 2 }}
       />
 

--- a/frontend/src/components/patient-generator/ScenarioSelector.tsx
+++ b/frontend/src/components/patient-generator/ScenarioSelector.tsx
@@ -43,6 +43,7 @@ export default function ScenarioSelector({ isGenerating, onGenerate }: ScenarioS
         selectedMedications: scenario.medications,
         selectedAllergies: [],
         numEncounters: scenario.num_encounters,
+        numPatients: scenario.recommended_patient_count,
       })
     },
     [onGenerate],

--- a/frontend/src/config/twcore/types.ts
+++ b/frontend/src/config/twcore/types.ts
@@ -79,6 +79,7 @@ export interface CustomGenerationConfig {
   selectedMedications: string[]
   selectedAllergies: string[]
   numEncounters: number
+  numPatients?: number
   dateFrom?: string
   dateTo?: string
 }

--- a/frontend/src/hooks/usePatientGenerator.ts
+++ b/frontend/src/hooks/usePatientGenerator.ts
@@ -36,8 +36,12 @@ export function usePatientGenerator(): UsePatientGeneratorReturn {
   const generateCustom = useCallback((config: CustomGenerationConfig) => {
     setIsGenerating(true)
     setTimeout(() => {
-      const data = generateCustomPatient(config)
-      setResults([data])
+      const count = config.numPatients ?? 1
+      const data: GeneratedPatientData[] = []
+      for (let i = 0; i < count; i++) {
+        data.push(generateCustomPatient(config))
+      }
+      setResults(data)
       setIsGenerating(false)
     }, 0)
   }, [])


### PR DESCRIPTION
## 變更說明

1. **假病人產生器情境模板**：點擊「使用此情境」現在依照 `recommended_patient_count` 產生正確數量的病人（原先固定只產生 1 位）。新增 `numPatients` 至 `CustomGenerationConfig`，`usePatientGenerator` 迴圈產生 N 位病人。

2. **期間比較指標選擇**：「指標名稱」從純文字 `TextField` 改為 `Autocomplete`，自動載入所有 MeasureDefinition 的 title。保留 `freeSolo` 允許手動輸入。

## 關聯 Issue

- Closes #130

## 測試紀錄

- [x] `npx tsc --noEmit` 型別檢查通過

## 風險評估

- 風險等級：低
- 影響範圍：PatientGeneratorPage 情境模板、MeasureComparison 指標選擇

## IEC 62304 / ISO 14971 追溯

| 項目 | 內容 |
|------|------|
| 變更類型 | 缺陷修復 + UX 改善 |
| 安全性等級 | A |
| 需求追溯 | #130 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)