### PR TITLE
refactor: simplify recent changes + update CHANGE_LOG

### DIFF
--- a/backend/src/main/java/com/cqlplatform/service/cql/CqlExecutionService.java
+++ b/backend/src/main/java/com/cqlplatform/service/cql/CqlExecutionService.java
@@ -147,8 +147,14 @@ public class CqlExecutionService {
             org.hl7.elm.r1.Library elmLibrary;
             CqlTranslator translator = null;
             if (request.getElmJson() != null && !request.getElmJson().isBlank()) {
-                log.debug("Using pre-compiled ELM, skipping CQL translation");
-                elmLibrary = ELM_MAPPER.readValue(request.getElmJson(), org.hl7.elm.r1.Library.class);
+                try {
+                    elmLibrary = ELM_MAPPER.readValue(request.getElmJson(), org.hl7.elm.r1.Library.class);
+                    log.debug("Using pre-compiled ELM, skipped CQL translation");
+                } catch (Exception e) {
+                    log.warn("Pre-compiled ELM deserialization failed, falling back to CQL translation: {}", e.getMessage());
+                    translator = CqlTranslator.fromText(request.getCql(), libraryManager);
+                    elmLibrary = translator.toELM();
+                }
             } else {
                 translator = CqlTranslator.fromText(request.getCql(), libraryManager);
                 elmLibrary = translator.toELM();

--- a/backend/src/main/java/com/cqlplatform/service/fhir/FhirTerminologyService.java
+++ b/backend/src/main/java/com/cqlplatform/service/fhir/FhirTerminologyService.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 @Slf4j
@@ -80,8 +81,8 @@ public class FhirTerminologyService {
         return new RestTemplate(factory);
     }
 
-    private final java.util.concurrent.ConcurrentHashMap<String, TerminologyProvider> terminologyProviderCache =
-            new java.util.concurrent.ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, TerminologyProvider> terminologyProviderCache =
+            new ConcurrentHashMap<>();
 
     public TerminologyProvider createTerminologyProvider(String terminologyServerUrl) {
         String serverUrl = terminologyServerUrl != null ? terminologyServerUrl : defaultTerminologyServerUrl;

--- a/backend/src/main/java/com/cqlplatform/service/measure/MeasureDefinitionService.java
+++ b/backend/src/main/java/com/cqlplatform/service/measure/MeasureDefinitionService.java
@@ -69,8 +69,11 @@ public class MeasureDefinitionService {
         entity.setStatus(definition.getStatus());
         entity.setScoringType(definition.getScoringType());
         entity.setCqlLibraryId(definition.getCqlLibraryId());
+        boolean cqlChanged = !java.util.Objects.equals(definition.getCqlContent(), entity.getCqlContent());
         entity.setCqlContent(definition.getCqlContent());
-        entity.setElmJson(preCompileElm(definition.getCqlContent()));
+        if (cqlChanged) {
+            entity.setElmJson(preCompileElm(definition.getCqlContent()));
+        }
         entity.setFhirMeasureJson(definition.getFhirMeasureJson());
         entity.setGroupDefinitionList(definition.getGroupDefinitions());
         entity.setCompositeScoring(definition.getCompositeScoring());

--- a/backend/src/main/java/com/cqlplatform/service/measure/MeasureEvaluationService.java
+++ b/backend/src/main/java/com/cqlplatform/service/measure/MeasureEvaluationService.java
@@ -7,7 +7,6 @@ import com.cqlplatform.model.measure.MeasureEvaluationResult.*;
 import com.cqlplatform.service.cql.CqlExecutionService;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.opencds.cqf.cql.engine.runtime.DateTime;
 import org.opencds.cqf.cql.engine.runtime.Interval;
@@ -179,6 +178,7 @@ public class MeasureEvaluationService {
                     .get(context.getTimeoutSeconds(), TimeUnit.SECONDS);
         } catch (Exception e) {
             log.warn("Measure evaluation timed out or interrupted after {}s", context.getTimeoutSeconds());
+            futures.forEach(f -> f.cancel(true));
         }
 
         // Aggregate results sequentially (thread-safe)

--- a/docs/CHANGE_LOG.md
+++ b/docs/CHANGE_LOG.md
@@ -9,6 +9,10 @@
 
 | ID | 類型 | 日期 | 範圍 | 標題 | 備註 | Commit |
 |-----|------|------|------|------|------|--------|
+| PAT-062 | ⚡ perf | 2026-03-24 | 後端（CQL Engine） | ELM 預編譯快取 — 儲存量測定義時自動翻譯 CQL→ELM JSON 並存入 DB，執行時反序列化 (~10ms) 取代即時翻譯 (~1.5s/次)，含 corrupt ELM fallback + metadata-only 更新跳過重編譯 | V44 migration、MeasureDefinitionService preCompileElm | [`9ef5a9f`](../../commit/9ef5a9f) [`b0d65fb`](../../commit/b0d65fb) |
+| BUG-100 | 🐛 bugfix | 2026-03-24 | 前端（病人產生器+品質指標） | 情境模板產生正確病人數 + 期間比較指標 Autocomplete — 情境模板原本固定只產生 1 位病人，改為依 recommended_patient_count 迴圈產生；期間比較「指標名稱」從純文字改為自動載入現有指標的下拉選單 | CustomGenerationConfig.numPatients、MeasureComparison Autocomplete | [`c2858c2`](../../commit/c2858c2) |
+| BUG-099 | ⚡ perf | 2026-03-24 | 後端（品質量測） | 量測評估平行化 + TerminologyProvider 快取 — 病人 CQL 評估從循序改為 CompletableFuture 平行執行（99s→~20s），TerminologyProvider 依 server URL 快取避免重複建立 FHIR 客戶端，修復 ForkJoinPool 死鎖 + timeout 取消 futures | MeasureEvaluationService、FhirTerminologyService | [`e98463d`](../../commit/e98463d) [`87c278d`](../../commit/87c278d) |
+| BUG-098 | 🐛 bugfix | 2026-03-24 | 前端（通知） | SSE 通知 JWT 靜默刷新 — SSE ticket 請求從原生 fetch 改為 Axios client，使過期 JWT 自動刷新，消除無限 401 重試迴圈 | useNotifications.ts | [`7720c98`](../../commit/7720c98) |
 | PAT-060 | ✨ feature | 2026-03-24 | 全端（EHR 連線） | SMART Backend Services 驗證 — EHR 連線新增 OAuth 2.0 client_credentials + JWT assertion (RS384) 驗證方式，含 token 自動快取/刷新、per-connection locking、SSRF 防護（tokenEndpoint 驗證）、權限修正（test/search/import 端點加 @PreAuthorize）| V43 migration、SmartBackendTokenService、nimbus-jose-jwt PEM 解析 | [`b7a5345`](../../commit/b7a5345) |
 | PAT-059 | ✨ feature | 2026-03-24 | 前端（病人產生器） | TW Core IG 假病人產生器 — 批次/自訂/情境模板三分頁，純前端 config-driven 架構（5 JSON 設定檔驅動 60+ 臨床項目），FHIR 資源產生（Patient/Encounter/Condition/Observation/Medication/MedicationRequest/AllergyIntolerance）+ 下載 JSON + 上傳 FHIR Server | 20 新檔案、新增 patientGenerator i18n namespace | [`c8b7512`](../../commit/c8b7512) |
 | BUG-095 | 🔧 refactor | 2026-03-16 | 前端（全模組） | 前端全面簡化 — 主題色彩/i18n/效能/佈局修復 | 136 檔、+1334/-1146 行 | [`525d244`](../../commit/525d244) |

--- a/frontend/src/components/measure/MeasureComparison.tsx
+++ b/frontend/src/components/measure/MeasureComparison.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getScoreThemeColor } from '../../utils/scoreColors'
 import { extractApiError } from '../../utils/errorUtils'
@@ -38,7 +38,7 @@ export default function MeasureComparison() {
     queryFn: () => measureApi.getMeasures(),
     staleTime: Infinity,
   })
-  const measureOptions = measures.map((m) => m.title || m.name)
+  const measureOptions = useMemo(() => measures.map((m) => m.title || m.name), [measures])
 
   const defaults = getDefaultComparisonPeriods()
   const [p1Start, setP1Start] = useState(defaults.period1Start)
@@ -80,7 +80,6 @@ export default function MeasureComparison() {
         freeSolo
         options={measureOptions}
         value={measureName}
-        onChange={(_e, value) => setMeasureName(value ?? '')}
         onInputChange={(_e, value) => setMeasureName(value)}
         renderInput={(params) => (
           <TextField {...params} label={t('comparison.measureName')} size="small" />


### PR DESCRIPTION
## 變更說明

1. **Code review 修正**（refactor commit）：
   - CqlExecutionService: corrupt ELM 反序列化 fallback 到即時翻譯
   - MeasureDefinitionService: metadata-only 更新跳過 ELM 重編譯
   - MeasureEvaluationService: timeout 後取消 futures + 移除 dead import
   - FhirTerminologyService: ConcurrentHashMap 改為正式 import
   - MeasureComparison: useMemo + 移除冗餘 onChange

2. **CHANGE_LOG 更新**：新增 BUG-098~100、PAT-062 記錄

## 關聯 Issue

- #127 #130 #132

## 測試紀錄

- [x] 全後端 823 測試通過
- [x] 前端型別檢查通過
- [x] 安全審查通過（0 漏洞）

## IEC 62304 / ISO 14971 追溯

| 項目 | 內容 |
|------|------|
| 變更類型 | 重構 + 文件 |
| 安全性等級 | A |

🤖 Generated with [Claude Code](https://claude.com/claude-code)