### PR TITLE
feat: FHIR Subscription 即時推送通知 (#PAT-067)

### DIFF
--- a/backend/src/main/java/com/cqlplatform/config/SecurityConfig.java
+++ b/backend/src/main/java/com/cqlplatform/config/SecurityConfig.java
@@ -103,6 +103,8 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST, "/api/auth/logout").permitAll()
                 // SMART on FHIR configuration
                 .requestMatchers("/.well-known/smart-configuration").permitAll()
+                // FHIR Subscription callback (external FHIR servers can't authenticate)
+                .requestMatchers(HttpMethod.POST, "/api/ehr/subscriptions/callback").permitAll()
                 // CDS Hooks sandbox requires authentication
                 .requestMatchers(HttpMethod.POST, "/cds-services/*/sandbox").authenticated()
                 // Per-user CDS endpoints (API key auth handled in filter)

--- a/backend/src/main/java/com/cqlplatform/controller/EhrIntegrationController.java
+++ b/backend/src/main/java/com/cqlplatform/controller/EhrIntegrationController.java
@@ -3,14 +3,17 @@ package com.cqlplatform.controller;
 import com.cqlplatform.entity.BatchImportJobEntity;
 import com.cqlplatform.entity.EhrConnectionEntity;
 import com.cqlplatform.entity.FailedImportEntity;
+import com.cqlplatform.entity.FhirSubscriptionEntity;
 import com.cqlplatform.entity.PatientImportEntity;
 import com.cqlplatform.model.ehr.BatchImportRequest;
 import com.cqlplatform.model.ehr.EhrConnectionRequest;
+import com.cqlplatform.model.ehr.SubscriptionRequest;
 import com.cqlplatform.model.fhir.PatientImportPreview;
 import com.cqlplatform.model.fhir.PatientSearchResult;
 import com.cqlplatform.security.InputValidator;
 import com.cqlplatform.service.fhir.AsyncPatientImportService;
 import com.cqlplatform.service.fhir.EhrConnectionService;
+import com.cqlplatform.service.fhir.FhirSubscriptionService;
 import com.cqlplatform.service.fhir.ImportRetryService;
 import com.cqlplatform.service.fhir.PatientImportService;
 import com.cqlplatform.service.fhir.PatientSearchService;
@@ -36,6 +39,7 @@ public class EhrIntegrationController {
     private final PatientImportService patientImportService;
     private final AsyncPatientImportService asyncImportService;
     private final ImportRetryService importRetryService;
+    private final FhirSubscriptionService subscriptionService;
 
     // ===== Connection Management =====
 
@@ -162,6 +166,57 @@ public class EhrIntegrationController {
     @Operation(summary = "Cancel Batch Import", description = "Cancel a running or pending batch import job")
     public ResponseEntity<BatchImportJobEntity> cancelBatchImport(@PathVariable Long jobId) {
         return ResponseEntity.ok(asyncImportService.cancelJob(jobId));
+    }
+
+    // ===== Subscriptions =====
+
+    @PostMapping("/connections/{id}/subscriptions")
+    @PreAuthorize("hasAnyRole('ADMIN','DEPARTMENT_ADMIN')")
+    @Operation(summary = "Create Subscription", description = "Create a FHIR Subscription on a remote EHR server")
+    public ResponseEntity<FhirSubscriptionEntity> createSubscription(
+            @PathVariable Long id,
+            @Valid @RequestBody SubscriptionRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(subscriptionService.createSubscription(id, request));
+    }
+
+    @GetMapping("/subscriptions")
+    @Operation(summary = "List Subscriptions", description = "List all FHIR Subscriptions")
+    public ResponseEntity<List<FhirSubscriptionEntity>> listSubscriptions(
+            @RequestParam(required = false) Long connectionId) {
+        return ResponseEntity.ok(subscriptionService.listSubscriptions(connectionId));
+    }
+
+    @GetMapping("/subscriptions/{id}")
+    @Operation(summary = "Get Subscription", description = "Get details of a FHIR Subscription")
+    public ResponseEntity<FhirSubscriptionEntity> getSubscription(@PathVariable Long id) {
+        return ResponseEntity.ok(subscriptionService.getSubscription(id));
+    }
+
+    @PostMapping("/subscriptions/{id}/sync")
+    @PreAuthorize("hasAnyRole('ADMIN','DEPARTMENT_ADMIN')")
+    @Operation(summary = "Sync Subscription Status", description = "Sync subscription status from remote FHIR server")
+    public ResponseEntity<FhirSubscriptionEntity> syncSubscriptionStatus(@PathVariable Long id) {
+        return ResponseEntity.ok(subscriptionService.syncStatus(id));
+    }
+
+    @DeleteMapping("/subscriptions/{id}")
+    @PreAuthorize("hasAnyRole('ADMIN','DEPARTMENT_ADMIN')")
+    @Operation(summary = "Delete Subscription", description = "Delete a FHIR Subscription from local and remote server")
+    public ResponseEntity<Void> deleteSubscription(@PathVariable Long id) {
+        subscriptionService.deleteSubscription(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/subscriptions/callback")
+    @Operation(summary = "Subscription Callback", description = "REST-hook callback endpoint for FHIR server notifications")
+    public ResponseEntity<Void> subscriptionCallback(
+            @RequestHeader(value = "X-Subscription-Id", required = false) String subscriptionId,
+            @RequestBody(required = false) String resourceJson) {
+        if (subscriptionId != null) {
+            subscriptionService.handleNotification(subscriptionId, resourceJson);
+        }
+        return ResponseEntity.ok().build();
     }
 
     // ===== Import History =====

--- a/backend/src/main/java/com/cqlplatform/entity/FhirSubscriptionEntity.java
+++ b/backend/src/main/java/com/cqlplatform/entity/FhirSubscriptionEntity.java
@@ -1,0 +1,64 @@
+package com.cqlplatform.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "fhir_subscription")
+@Data
+public class FhirSubscriptionEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "connection_id", nullable = false)
+    private Long connectionId;
+
+    @Column(name = "fhir_subscription_id", length = 200)
+    private String fhirSubscriptionId;
+
+    @Column(nullable = false, length = 500)
+    private String criteria;
+
+    @Column(name = "channel_type", nullable = false, length = 20)
+    private String channelType = "rest-hook";
+
+    @Column(name = "callback_url", nullable = false, length = 500)
+    private String callbackUrl;
+
+    @Column(nullable = false, length = 20)
+    private String status = "requested";
+
+    @Column(length = 500)
+    private String reason;
+
+    @Column(name = "error_message", length = 1000)
+    private String errorMessage;
+
+    @Column(name = "last_notification_at")
+    private LocalDateTime lastNotificationAt;
+
+    @Column(name = "notification_count", nullable = false)
+    private int notificationCount;
+
+    @Column(name = "created_by", nullable = false, length = 100)
+    private String createdBy;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = createdAt;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/cqlplatform/model/ehr/SubscriptionRequest.java
+++ b/backend/src/main/java/com/cqlplatform/model/ehr/SubscriptionRequest.java
@@ -1,0 +1,15 @@
+package com.cqlplatform.model.ehr;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class SubscriptionRequest {
+    @NotBlank(message = "Subscription criteria is required")
+    @Size(max = 500)
+    private String criteria;
+
+    @Size(max = 500)
+    private String reason;
+}

--- a/backend/src/main/java/com/cqlplatform/repository/FhirSubscriptionRepository.java
+++ b/backend/src/main/java/com/cqlplatform/repository/FhirSubscriptionRepository.java
@@ -1,0 +1,13 @@
+package com.cqlplatform.repository;
+
+import com.cqlplatform.entity.FhirSubscriptionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+import java.util.Optional;
+
+public interface FhirSubscriptionRepository extends JpaRepository<FhirSubscriptionEntity, Long> {
+    List<FhirSubscriptionEntity> findByConnectionIdOrderByCreatedAtDesc(Long connectionId);
+    List<FhirSubscriptionEntity> findByStatusOrderByCreatedAtDesc(String status);
+    List<FhirSubscriptionEntity> findAllByOrderByCreatedAtDesc();
+    Optional<FhirSubscriptionEntity> findByFhirSubscriptionId(String fhirSubscriptionId);
+}

--- a/backend/src/main/java/com/cqlplatform/service/fhir/FhirSubscriptionService.java
+++ b/backend/src/main/java/com/cqlplatform/service/fhir/FhirSubscriptionService.java
@@ -1,0 +1,179 @@
+package com.cqlplatform.service.fhir;
+
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import com.cqlplatform.entity.EhrConnectionEntity;
+import com.cqlplatform.entity.FhirSubscriptionEntity;
+import com.cqlplatform.exception.ResourceNotFoundException;
+import com.cqlplatform.model.ehr.SubscriptionRequest;
+import com.cqlplatform.repository.FhirSubscriptionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.r4.model.Subscription;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FhirSubscriptionService {
+
+    private final FhirSubscriptionRepository subscriptionRepository;
+    private final EhrConnectionService connectionService;
+    private final FhirClientFactory fhirClientFactory;
+
+    @Value("${server.port:8080}")
+    private int serverPort;
+
+    @Value("${fhir.subscription.callback-base-url:}")
+    private String callbackBaseUrl;
+
+    @Transactional
+    public FhirSubscriptionEntity createSubscription(Long connectionId, SubscriptionRequest request) {
+        EhrConnectionEntity connection = connectionService.getById(connectionId);
+        IGenericClient client = fhirClientFactory.createAuthenticatedClient(connection);
+
+        String callbackUrl = resolveCallbackUrl();
+
+        // Build FHIR Subscription resource
+        Subscription subscription = new Subscription();
+        subscription.setStatus(Subscription.SubscriptionStatus.REQUESTED);
+        subscription.setCriteria(request.getCriteria());
+        subscription.setReason(request.getReason() != null ? request.getReason() : "CQL Platform data sync");
+
+        Subscription.SubscriptionChannelComponent channel = new Subscription.SubscriptionChannelComponent();
+        channel.setType(Subscription.SubscriptionChannelType.RESTHOOK);
+        channel.setEndpoint(callbackUrl);
+        channel.setPayload("application/fhir+json");
+        subscription.setChannel(channel);
+
+        // Create on remote FHIR server
+        FhirSubscriptionEntity entity = new FhirSubscriptionEntity();
+        entity.setConnectionId(connectionId);
+        entity.setCriteria(request.getCriteria());
+        entity.setCallbackUrl(callbackUrl);
+        entity.setReason(request.getReason());
+        entity.setCreatedBy(getCurrentUsername());
+
+        try {
+            var outcome = client.create().resource(subscription).execute();
+            String subscriptionId = outcome.getId().getIdPart();
+            entity.setFhirSubscriptionId(subscriptionId);
+            entity.setStatus("active");
+            log.info("Created FHIR Subscription {} on connection {} (criteria: {})",
+                    subscriptionId, connectionId, request.getCriteria());
+        } catch (Exception e) {
+            entity.setStatus("error");
+            entity.setErrorMessage(truncate(e.getMessage(), 1000));
+            log.warn("Failed to create FHIR Subscription on connection {}: {}",
+                    connectionId, e.getMessage());
+        }
+
+        return subscriptionRepository.save(entity);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FhirSubscriptionEntity> listSubscriptions(Long connectionId) {
+        if (connectionId != null) {
+            return subscriptionRepository.findByConnectionIdOrderByCreatedAtDesc(connectionId);
+        }
+        return subscriptionRepository.findAllByOrderByCreatedAtDesc();
+    }
+
+    @Transactional(readOnly = true)
+    public FhirSubscriptionEntity getSubscription(Long id) {
+        return subscriptionRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Subscription not found: " + id));
+    }
+
+    @Transactional
+    public void deleteSubscription(Long id) {
+        FhirSubscriptionEntity entity = getSubscription(id);
+
+        // Try to delete from remote FHIR server
+        if (entity.getFhirSubscriptionId() != null) {
+            try {
+                EhrConnectionEntity connection = connectionService.getById(entity.getConnectionId());
+                IGenericClient client = fhirClientFactory.createAuthenticatedClient(connection);
+                client.delete().resourceById("Subscription", entity.getFhirSubscriptionId()).execute();
+                log.info("Deleted FHIR Subscription {} from connection {}",
+                        entity.getFhirSubscriptionId(), entity.getConnectionId());
+            } catch (Exception e) {
+                log.warn("Failed to delete remote Subscription {}: {}",
+                        entity.getFhirSubscriptionId(), e.getMessage());
+            }
+        }
+
+        subscriptionRepository.delete(entity);
+    }
+
+    @Transactional
+    public FhirSubscriptionEntity syncStatus(Long id) {
+        FhirSubscriptionEntity entity = getSubscription(id);
+        if (entity.getFhirSubscriptionId() == null) {
+            return entity;
+        }
+
+        try {
+            EhrConnectionEntity connection = connectionService.getById(entity.getConnectionId());
+            IGenericClient client = fhirClientFactory.createAuthenticatedClient(connection);
+            Subscription remote = client.read()
+                    .resource(Subscription.class)
+                    .withId(entity.getFhirSubscriptionId())
+                    .execute();
+
+            entity.setStatus(remote.getStatus() != null ? remote.getStatus().toCode() : "unknown");
+            entity.setErrorMessage(remote.hasError() ? remote.getError() : null);
+        } catch (Exception e) {
+            entity.setStatus("error");
+            entity.setErrorMessage("Status sync failed: " + truncate(e.getMessage(), 900));
+        }
+
+        return subscriptionRepository.save(entity);
+    }
+
+    /**
+     * Handle incoming REST-hook notification from a FHIR server.
+     */
+    @Transactional
+    public void handleNotification(String subscriptionId, String resourceJson) {
+        FhirSubscriptionEntity entity = subscriptionRepository.findByFhirSubscriptionId(subscriptionId)
+                .orElse(null);
+
+        if (entity == null) {
+            log.warn("Received notification for unknown subscription: {}", subscriptionId);
+            return;
+        }
+
+        entity.setLastNotificationAt(LocalDateTime.now());
+        entity.setNotificationCount(entity.getNotificationCount() + 1);
+        subscriptionRepository.save(entity);
+
+        log.info("Received notification #{} for subscription {} (connection {})",
+                entity.getNotificationCount(), subscriptionId, entity.getConnectionId());
+    }
+
+    private String resolveCallbackUrl() {
+        if (callbackBaseUrl != null && !callbackBaseUrl.isBlank()) {
+            return callbackBaseUrl + "/api/ehr/subscriptions/callback";
+        }
+        return "http://localhost:" + serverPort + "/api/ehr/subscriptions/callback";
+    }
+
+    private String getCurrentUsername() {
+        try {
+            var auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth != null && auth.getName() != null) return auth.getName();
+        } catch (Exception ignored) {}
+        return "system";
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value == null) return null;
+        return value.length() > maxLength ? value.substring(0, maxLength) : value;
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -166,6 +166,8 @@ fhir:
     url: ${FHIR_TERMINOLOGY_URL:https://tx.fhir.org/r4}
   implementation-guides:
     enabled: ${FHIR_IG_ENABLED:true}
+  subscription:
+    callback-base-url: ${FHIR_SUBSCRIPTION_CALLBACK_URL:}
   client:
     pool-max-total: 50
     pool-default-per-route: 30

--- a/backend/src/main/resources/db/migration/V49__fhir_subscription.sql
+++ b/backend/src/main/resources/db/migration/V49__fhir_subscription.sql
@@ -1,0 +1,19 @@
+CREATE TABLE fhir_subscription (
+    id BIGSERIAL PRIMARY KEY,
+    connection_id BIGINT NOT NULL,
+    fhir_subscription_id VARCHAR(200),
+    criteria VARCHAR(500) NOT NULL,
+    channel_type VARCHAR(20) NOT NULL DEFAULT 'rest-hook',
+    callback_url VARCHAR(500) NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'requested',
+    reason VARCHAR(500),
+    error_message VARCHAR(1000),
+    last_notification_at TIMESTAMP,
+    notification_count INT NOT NULL DEFAULT 0,
+    created_by VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_fhir_subscription_connection ON fhir_subscription (connection_id);
+CREATE INDEX idx_fhir_subscription_status ON fhir_subscription (status);

--- a/backend/src/main/resources/db/rollback/rollback_V49__fhir_subscription.sql
+++ b/backend/src/main/resources/db/rollback/rollback_V49__fhir_subscription.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_fhir_subscription_status;
+DROP INDEX IF EXISTS idx_fhir_subscription_connection;
+DROP TABLE IF EXISTS fhir_subscription;

--- a/backend/src/test/java/com/cqlplatform/service/fhir/FhirSubscriptionServiceTest.java
+++ b/backend/src/test/java/com/cqlplatform/service/fhir/FhirSubscriptionServiceTest.java
@@ -1,0 +1,252 @@
+package com.cqlplatform.service.fhir;
+
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.gclient.ICreate;
+import ca.uhn.fhir.rest.gclient.ICreateTyped;
+import ca.uhn.fhir.rest.gclient.IDelete;
+import ca.uhn.fhir.rest.gclient.IDeleteTyped;
+import ca.uhn.fhir.rest.gclient.IRead;
+import ca.uhn.fhir.rest.gclient.IReadExecutable;
+import ca.uhn.fhir.rest.gclient.IReadTyped;
+import com.cqlplatform.entity.EhrConnectionEntity;
+import com.cqlplatform.entity.FhirSubscriptionEntity;
+import com.cqlplatform.exception.ResourceNotFoundException;
+import com.cqlplatform.model.ehr.SubscriptionRequest;
+import com.cqlplatform.repository.FhirSubscriptionRepository;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Subscription;
+import ca.uhn.fhir.rest.api.MethodOutcome;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FhirSubscriptionServiceTest {
+
+    @Mock
+    private FhirSubscriptionRepository subscriptionRepository;
+
+    @Mock
+    private EhrConnectionService connectionService;
+
+    @Mock
+    private FhirClientFactory fhirClientFactory;
+
+    @InjectMocks
+    private FhirSubscriptionService service;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(service, "serverPort", 8080);
+        ReflectionTestUtils.setField(service, "callbackBaseUrl", "http://test:8080");
+    }
+
+    @Test
+    void createSubscription_success_shouldSetActiveStatus() {
+        Long connectionId = 1L;
+        SubscriptionRequest request = new SubscriptionRequest();
+        request.setCriteria("Patient?_lastUpdated=gt2024-01-01");
+        request.setReason("Test sync");
+
+        EhrConnectionEntity connection = new EhrConnectionEntity();
+        connection.setId(connectionId);
+        when(connectionService.getById(connectionId)).thenReturn(connection);
+
+        IGenericClient client = mock(IGenericClient.class);
+        when(fhirClientFactory.createAuthenticatedClient(connection)).thenReturn(client);
+
+        ICreate create = mock(ICreate.class);
+        ICreateTyped createTyped = mock(ICreateTyped.class);
+        when(client.create()).thenReturn(create);
+        when(create.resource(any(Subscription.class))).thenReturn(createTyped);
+
+        MethodOutcome outcome = new MethodOutcome();
+        outcome.setId(new IdType("Subscription", "sub-123"));
+        when(createTyped.execute()).thenReturn(outcome);
+
+        when(subscriptionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        FhirSubscriptionEntity result = service.createSubscription(connectionId, request);
+
+        assertThat(result.getStatus()).isEqualTo("active");
+        assertThat(result.getFhirSubscriptionId()).isEqualTo("sub-123");
+        assertThat(result.getCriteria()).isEqualTo("Patient?_lastUpdated=gt2024-01-01");
+        assertThat(result.getCallbackUrl()).isEqualTo("http://test:8080/api/ehr/subscriptions/callback");
+    }
+
+    @Test
+    void createSubscription_failure_shouldSetErrorStatus() {
+        Long connectionId = 1L;
+        SubscriptionRequest request = new SubscriptionRequest();
+        request.setCriteria("Patient?_lastUpdated=gt2024-01-01");
+
+        EhrConnectionEntity connection = new EhrConnectionEntity();
+        connection.setId(connectionId);
+        when(connectionService.getById(connectionId)).thenReturn(connection);
+
+        IGenericClient client = mock(IGenericClient.class);
+        when(fhirClientFactory.createAuthenticatedClient(connection)).thenReturn(client);
+
+        ICreate create = mock(ICreate.class);
+        ICreateTyped createTyped = mock(ICreateTyped.class);
+        when(client.create()).thenReturn(create);
+        when(create.resource(any(Subscription.class))).thenReturn(createTyped);
+        when(createTyped.execute()).thenThrow(new RuntimeException("Connection refused"));
+
+        when(subscriptionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        FhirSubscriptionEntity result = service.createSubscription(connectionId, request);
+
+        assertThat(result.getStatus()).isEqualTo("error");
+        assertThat(result.getErrorMessage()).contains("Connection refused");
+        assertThat(result.getFhirSubscriptionId()).isNull();
+    }
+
+    @Test
+    void listSubscriptions_withConnectionId_shouldFilter() {
+        Long connectionId = 1L;
+        FhirSubscriptionEntity entity = new FhirSubscriptionEntity();
+        entity.setConnectionId(connectionId);
+        when(subscriptionRepository.findByConnectionIdOrderByCreatedAtDesc(connectionId))
+                .thenReturn(List.of(entity));
+
+        List<FhirSubscriptionEntity> result = service.listSubscriptions(connectionId);
+
+        assertThat(result).hasSize(1);
+        verify(subscriptionRepository).findByConnectionIdOrderByCreatedAtDesc(connectionId);
+        verify(subscriptionRepository, never()).findAllByOrderByCreatedAtDesc();
+    }
+
+    @Test
+    void listSubscriptions_withoutConnectionId_shouldReturnAll() {
+        FhirSubscriptionEntity entity = new FhirSubscriptionEntity();
+        when(subscriptionRepository.findAllByOrderByCreatedAtDesc())
+                .thenReturn(List.of(entity));
+
+        List<FhirSubscriptionEntity> result = service.listSubscriptions(null);
+
+        assertThat(result).hasSize(1);
+        verify(subscriptionRepository).findAllByOrderByCreatedAtDesc();
+        verify(subscriptionRepository, never()).findByConnectionIdOrderByCreatedAtDesc(any());
+    }
+
+    @Test
+    void getSubscription_found_shouldReturn() {
+        FhirSubscriptionEntity entity = new FhirSubscriptionEntity();
+        entity.setId(1L);
+        when(subscriptionRepository.findById(1L)).thenReturn(Optional.of(entity));
+
+        FhirSubscriptionEntity result = service.getSubscription(1L);
+
+        assertThat(result.getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void getSubscription_notFound_shouldThrow() {
+        when(subscriptionRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getSubscription(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    void deleteSubscription_shouldDeleteLocalAndRemote() {
+        FhirSubscriptionEntity entity = new FhirSubscriptionEntity();
+        entity.setId(1L);
+        entity.setConnectionId(10L);
+        entity.setFhirSubscriptionId("sub-123");
+        when(subscriptionRepository.findById(1L)).thenReturn(Optional.of(entity));
+
+        EhrConnectionEntity connection = new EhrConnectionEntity();
+        when(connectionService.getById(10L)).thenReturn(connection);
+
+        IGenericClient client = mock(IGenericClient.class);
+        when(fhirClientFactory.createAuthenticatedClient(connection)).thenReturn(client);
+
+        IDelete delete = mock(IDelete.class);
+        IDeleteTyped deleteTyped = mock(IDeleteTyped.class);
+        when(client.delete()).thenReturn(delete);
+        when(delete.resourceById("Subscription", "sub-123")).thenReturn(deleteTyped);
+
+        service.deleteSubscription(1L);
+
+        verify(deleteTyped).execute();
+        verify(subscriptionRepository).delete(entity);
+    }
+
+    @Test
+    void handleNotification_knownSubscription_shouldIncrementCount() {
+        FhirSubscriptionEntity entity = new FhirSubscriptionEntity();
+        entity.setFhirSubscriptionId("sub-123");
+        entity.setNotificationCount(5);
+        entity.setConnectionId(1L);
+        when(subscriptionRepository.findByFhirSubscriptionId("sub-123"))
+                .thenReturn(Optional.of(entity));
+        when(subscriptionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.handleNotification("sub-123", "{\"resourceType\":\"Patient\"}");
+
+        assertThat(entity.getNotificationCount()).isEqualTo(6);
+        assertThat(entity.getLastNotificationAt()).isNotNull();
+        verify(subscriptionRepository).save(entity);
+    }
+
+    @Test
+    void handleNotification_unknownSubscription_shouldLogWarning() {
+        when(subscriptionRepository.findByFhirSubscriptionId("unknown"))
+                .thenReturn(Optional.empty());
+
+        service.handleNotification("unknown", "{}");
+
+        verify(subscriptionRepository, never()).save(any());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void syncStatus_shouldUpdateFromRemote() {
+        FhirSubscriptionEntity entity = new FhirSubscriptionEntity();
+        entity.setId(1L);
+        entity.setConnectionId(10L);
+        entity.setFhirSubscriptionId("sub-123");
+        entity.setStatus("requested");
+        when(subscriptionRepository.findById(1L)).thenReturn(Optional.of(entity));
+
+        EhrConnectionEntity connection = new EhrConnectionEntity();
+        when(connectionService.getById(10L)).thenReturn(connection);
+
+        IGenericClient client = mock(IGenericClient.class);
+        when(fhirClientFactory.createAuthenticatedClient(connection)).thenReturn(client);
+
+        Subscription remote = new Subscription();
+        remote.setStatus(Subscription.SubscriptionStatus.ACTIVE);
+
+        IRead read = mock(IRead.class);
+        IReadTyped<Subscription> readTyped = mock(IReadTyped.class);
+        IReadExecutable<Subscription> readExecutable = mock(IReadExecutable.class);
+        when(client.read()).thenReturn(read);
+        when(read.resource(Subscription.class)).thenReturn(readTyped);
+        when(readTyped.withId("sub-123")).thenReturn(readExecutable);
+        when(readExecutable.execute()).thenReturn(remote);
+
+        when(subscriptionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        FhirSubscriptionEntity result = service.syncStatus(1L);
+
+        assertThat(result.getStatus()).isEqualTo("active");
+    }
+}


### PR DESCRIPTION
## 變更說明
支援 FHIR R4 Subscription 即時推送通知（REST-hook）。
## 變更類型
- [x] ✨ feat：新功能
- [x] 🧪 test：測試
## 關聯 Issue
- #151
## 測試紀錄
- [x] 後端測試通過：FhirSubscriptionServiceTest (10 tests)
## 風險評估
| 項目 | 說明 |
|------|------|
| 風險等級 | 低 |
| 影響範圍 | EHR 模組新增功能 |
| 回歸風險 | 低 |
## 安全性確認
- [x] 本次變更不涉及安全性等級 B/C 的功能
- [x] Callback endpoint 設為 public
## IEC 62304 / ISO 14971 追溯
| 類型 | Issue |
|------|-------|
| 需求 | #151 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)