### PR TITLE
fix: add ATC coding to MedicationRequest for CQL eQCM compatibility (#BUG-014)

### DIFF
--- a/frontend/src/utils/fhirPatientGenerator.ts
+++ b/frontend/src/utils/fhirPatientGenerator.ts
@@ -97,7 +97,7 @@ function generateMedicationPair(
   dateTo?: string,
 ): { medication: FhirResource; request: FhirResource } {
   const med = generateMedication(item)
-  const request = generateMedicationRequest(patientId, med.id as string, dateFrom, dateTo)
+  const request = generateMedicationRequest(patientId, med.id as string, item, dateFrom, dateTo)
   return { medication: med, request }
 }
 
@@ -284,6 +284,7 @@ export function generateMedication(item: MedicationItem): FhirResource {
 export function generateMedicationRequest(
   patientId: string,
   medicationId: string,
+  item: MedicationItem,
   dateFrom?: string,
   dateTo?: string,
 ): FhirResource {
@@ -291,11 +292,27 @@ export function generateMedicationRequest(
   const instruction = randomElement(MEDICATION_INSTRUCTIONS)
   const id = nextId('medreq')
 
+  // Build medication coding with both RxNorm and ATC codes for CQL compatibility
+  const medicationCoding: Array<{system: string; code: string; display: string}> = [
+    { system: item.system, code: item.code, display: item.display },
+  ]
+  if (item.atc) {
+    medicationCoding.push({
+      system: 'http://www.whocc.no/atc',
+      code: item.atc,
+      display: item.display,
+    })
+  }
+
   return {
     resourceType: 'MedicationRequest',
     id,
     status: 'active',
     intent: 'order',
+    medicationCodeableConcept: {
+      coding: medicationCoding,
+      text: item.display,
+    },
     medicationReference: { reference: `Medication/${medicationId}` },
     subject: { reference: `Patient/${patientId}` },
     authoredOn: date,


### PR DESCRIPTION
## 變更說明

修正病人產生器產生的 MedicationRequest 缺少 ATC 代碼，導致 eQCM 糖尿病 CQL 評估分母為 0 的問題。

### 根因
CQL 的 `"Diabetes Medications"` 定義檢查 `MR.medication.coding` 中 ATC system (`http://www.whocc.no/atc`) 且 code 以 `A10` 開頭。但產生的 MedicationRequest 只有 `medicationReference`（指向 Medication 資源），CQL 引擎無法透過 reference 追蹤到 Medication 的 code。

### 修正
`generateMedicationRequest` 現在同時輸出 `medicationCodeableConcept`，包含 RxNorm + ATC 雙 coding，讓 CQL 能直接在 MedicationRequest 上讀到 ATC code。

## 關聯 Issue

Closes #149

## 測試紀錄

- [x] TypeScript 編譯通過
- [x] 糖尿病情境：MedicationRequest 包含 ATC code `A10BA02`/`A10AB01`/`A10BB12`

## 風險評估

低風險 — 新增欄位不影響既有功能

## IEC 62304 / ISO 14971 追溯

| 項目 | 內容 |
|------|------|
| 需求 Issue | #149 |
| 安全性等級 | A |

🤖 Generated with [Claude Code](https://claude.com/claude-code)