### PR TITLE
fix: surface CQL translation errors instead of silent null (#BUG-015)

### DIFF
--- a/backend/src/main/java/com/cqlplatform/config/AsyncConfig.java
+++ b/backend/src/main/java/com/cqlplatform/config/AsyncConfig.java
@@ -32,6 +32,9 @@ public class AsyncConfig {
                     Thread t = new Thread(r);
                     t.setName("cql-exec-" + t.getId());
                     t.setDaemon(false);
+                    // Inherit the Spring Boot LaunchedURLClassLoader so that
+                    // ServiceLoader-based CQL model discovery works correctly
+                    t.setContextClassLoader(Thread.currentThread().getContextClassLoader());
                     return t;
                 },
                 new ThreadPoolExecutor.CallerRunsPolicy());

--- a/backend/src/main/java/com/cqlplatform/service/cql/CqlExecutionService.java
+++ b/backend/src/main/java/com/cqlplatform/service/cql/CqlExecutionService.java
@@ -14,6 +14,7 @@ import com.cqlplatform.service.fhir.FhirTerminologyService;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
+import org.cqframework.cql.cql2elm.CqlCompilerException;
 import org.cqframework.cql.cql2elm.CqlTranslator;
 import org.cqframework.cql.cql2elm.LibraryManager;
 import org.cqframework.cql.cql2elm.ModelManager;
@@ -159,6 +160,30 @@ public class CqlExecutionService {
                 translator = CqlTranslator.fromText(request.getCql(), libraryManager);
                 elmLibrary = translator.toELM();
             }
+
+            // Check for translation errors — previously these were silently swallowed,
+            // causing null EvaluationResult downstream
+            if (translator != null && translator.getExceptions() != null) {
+                List<CqlCompilerException> errors = translator.getExceptions().stream()
+                        .filter(e -> e.getSeverity() == CqlCompilerException.ErrorSeverity.Error)
+                        .toList();
+                if (!errors.isEmpty()) {
+                    String errorSummary = errors.stream()
+                            .map(CqlCompilerException::getMessage)
+                            .limit(5)
+                            .collect(java.util.stream.Collectors.joining("; "));
+                    log.error("CQL translation produced {} error(s): {}", errors.size(), errorSummary);
+                    throw new CqlExecutionException("CQL translation failed with " + errors.size()
+                            + " error(s): " + errorSummary);
+                }
+                long warnCount = translator.getExceptions().stream()
+                        .filter(e -> e.getSeverity() == CqlCompilerException.ErrorSeverity.Warning)
+                        .count();
+                if (warnCount > 0) {
+                    log.warn("CQL translation produced {} warning(s)", warnCount);
+                }
+            }
+
             org.hl7.elm.r1.VersionedIdentifier libraryId = elmLibrary.getIdentifier();
 
             // Extract source locators and dependencies for debug mode

--- a/backend/src/main/java/com/cqlplatform/service/cql/LibraryManagerFactory.java
+++ b/backend/src/main/java/com/cqlplatform/service/cql/LibraryManagerFactory.java
@@ -25,6 +25,25 @@ public final class LibraryManagerFactory {
      * Creates a LibraryManager with the given compiler options.
      */
     public static LibraryManager create(CqlLibraryRepository libraryRepository, CqlCompilerOptions options) {
+        // Ensure the context class loader is set correctly for ServiceLoader-based
+        // model discovery (System model, FHIR model). Worker threads in
+        // ThreadPoolExecutor / ForkJoinPool may lose the Spring Boot LaunchedURLClassLoader,
+        // causing "Could not load model information for model System" errors.
+        ClassLoader originalCl = Thread.currentThread().getContextClassLoader();
+        ClassLoader targetCl = LibraryManagerFactory.class.getClassLoader();
+        if (originalCl != targetCl) {
+            Thread.currentThread().setContextClassLoader(targetCl);
+        }
+        try {
+            return doCreate(libraryRepository, options);
+        } finally {
+            if (originalCl != targetCl) {
+                Thread.currentThread().setContextClassLoader(originalCl);
+            }
+        }
+    }
+
+    private static LibraryManager doCreate(CqlLibraryRepository libraryRepository, CqlCompilerOptions options) {
         ModelManager modelManager = new ModelManager();
         LibraryManager libraryManager = new LibraryManager(modelManager, options);
 


### PR DESCRIPTION
## 變更說明

修正 CQL 翻譯錯誤被靜默吞掉的問題。之前翻譯有 error 時，CQL 引擎回傳 null EvaluationResult，所有 expression 靜默失敗，分母/分子全部為 0，完全沒有錯誤訊息。

### 修正
CqlExecutionService 翻譯後檢查 `translator.getExceptions()`：
- Error 等級：log + 拋出 CqlExecutionException（含前 5 個錯誤訊息摘要）
- Warning 等級：僅 log

同時修正了資料庫中糖尿病 CQL 的語法問題：
- `Coding.code.value` → `Coding.code`
- `MR.medication.coding` → `(MR.medication as CodeableConcept).coding`
- HbA1c LOINC code `4548-4`（Hematocrit）→ `17856-6`（正確的 HbA1c）

## 關聯 Issue

Closes #150

## 測試紀錄

- [x] 編譯通過
- [x] CqlExecutionIntegrationTest 全部通過

## 風險評估

中 — 影響 CQL 執行結果的可觀測性

## IEC 62304 / ISO 14971 追溯

| 項目 | 內容 |
|------|------|
| 需求 Issue | #150 |
| 安全性等級 | B |

🤖 Generated with [Claude Code](https://claude.com/claude-code)