### PR TITLE
fix: CQL engine reliability, population hierarchy, and evaluation performance (#BUG-015)

### DIFF
--- a/backend/src/main/java/com/cqlplatform/config/AsyncConfig.java
+++ b/backend/src/main/java/com/cqlplatform/config/AsyncConfig.java
@@ -32,6 +32,9 @@ public class AsyncConfig {
                     Thread t = new Thread(r);
                     t.setName("cql-exec-" + t.getId());
                     t.setDaemon(false);
+                    // Inherit the Spring Boot LaunchedURLClassLoader so that
+                    // ServiceLoader-based CQL model discovery works correctly
+                    t.setContextClassLoader(Thread.currentThread().getContextClassLoader());
                     return t;
                 },
                 new ThreadPoolExecutor.CallerRunsPolicy());

--- a/backend/src/main/java/com/cqlplatform/service/cql/ClasspathLibrarySourceProvider.java
+++ b/backend/src/main/java/com/cqlplatform/service/cql/ClasspathLibrarySourceProvider.java
@@ -36,9 +36,23 @@ public class ClasspathLibrarySourceProvider implements LibrarySourceProvider {
 
     private Source tryLoadResource(String fileName) {
         try {
-            ClassPathResource resource = new ClassPathResource(basePath + fileName);
+            String path = basePath + fileName;
+            ClassPathResource resource = new ClassPathResource(path);
             if (resource.exists()) {
                 InputStream is = resource.getInputStream();
+                return CoreKt.buffered(JvmCoreKt.asSource(is));
+            }
+            // Try with thread context class loader explicitly
+            ClassLoader tcl = Thread.currentThread().getContextClassLoader();
+            if (tcl != null) {
+                InputStream is = tcl.getResourceAsStream(path);
+                if (is != null) {
+                    return CoreKt.buffered(JvmCoreKt.asSource(is));
+                }
+            }
+            // Try with this class's class loader
+            InputStream is = ClasspathLibrarySourceProvider.class.getClassLoader().getResourceAsStream(path);
+            if (is != null) {
                 return CoreKt.buffered(JvmCoreKt.asSource(is));
             }
         } catch (Exception e) {

--- a/backend/src/main/java/com/cqlplatform/service/cql/CqlExecutionService.java
+++ b/backend/src/main/java/com/cqlplatform/service/cql/CqlExecutionService.java
@@ -14,6 +14,7 @@ import com.cqlplatform.service.fhir.FhirTerminologyService;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
+import org.cqframework.cql.cql2elm.CqlCompilerException;
 import org.cqframework.cql.cql2elm.CqlTranslator;
 import org.cqframework.cql.cql2elm.LibraryManager;
 import org.cqframework.cql.cql2elm.ModelManager;
@@ -159,6 +160,30 @@ public class CqlExecutionService {
                 translator = CqlTranslator.fromText(request.getCql(), libraryManager);
                 elmLibrary = translator.toELM();
             }
+
+            // Check for translation errors — previously these were silently swallowed,
+            // causing null EvaluationResult downstream
+            if (translator != null && translator.getExceptions() != null) {
+                List<CqlCompilerException> errors = translator.getExceptions().stream()
+                        .filter(e -> e.getSeverity() == CqlCompilerException.ErrorSeverity.Error)
+                        .toList();
+                if (!errors.isEmpty()) {
+                    String errorSummary = errors.stream()
+                            .map(CqlCompilerException::getMessage)
+                            .limit(5)
+                            .collect(java.util.stream.Collectors.joining("; "));
+                    log.error("CQL translation produced {} error(s): {}", errors.size(), errorSummary);
+                    throw new CqlExecutionException("CQL translation failed with " + errors.size()
+                            + " error(s): " + errorSummary);
+                }
+                long warnCount = translator.getExceptions().stream()
+                        .filter(e -> e.getSeverity() == CqlCompilerException.ErrorSeverity.Warning)
+                        .count();
+                if (warnCount > 0) {
+                    log.warn("CQL translation produced {} warning(s)", warnCount);
+                }
+            }
+
             org.hl7.elm.r1.VersionedIdentifier libraryId = elmLibrary.getIdentifier();
 
             // Extract source locators and dependencies for debug mode

--- a/backend/src/main/java/com/cqlplatform/service/cql/LibraryManagerFactory.java
+++ b/backend/src/main/java/com/cqlplatform/service/cql/LibraryManagerFactory.java
@@ -1,21 +1,41 @@
 package com.cqlplatform.service.cql;
 
 import com.cqlplatform.repository.CqlLibraryRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
 import org.cqframework.cql.cql2elm.CqlCompilerOptions;
 import org.cqframework.cql.cql2elm.LibraryManager;
 import org.cqframework.cql.cql2elm.ModelManager;
+import org.springframework.stereotype.Component;
 
 /**
  * Creates a pre-configured LibraryManager with database and classpath library providers.
- * Centralizes the setup that was previously duplicated in CqlTranslationService and CqlExecutionService.
+ *
+ * <p>A single {@link ModelManager} is created once during Spring initialization
+ * (via {@code @PostConstruct}) on the main thread where the Spring Boot
+ * {@code LaunchedURLClassLoader} is the context class loader. This avoids
+ * {@code ServiceLoader} failures in worker threads (ForkJoinPool, ThreadPoolExecutor)
+ * that have a different context class loader.</p>
  */
-public final class LibraryManagerFactory {
+@Slf4j
+@Component
+public class LibraryManagerFactory {
 
-    private LibraryManagerFactory() {}
+    private static volatile ModelManager sharedModelManager;
+
+    @PostConstruct
+    void init() {
+        // Create ModelManager on the Spring main thread where the correct class loader is set.
+        // ModelManager uses ServiceLoader internally to discover ModelInfoProviders.
+        log.info("Initializing shared CQL ModelManager on thread: {} with classloader: {}",
+                Thread.currentThread().getName(),
+                Thread.currentThread().getContextClassLoader());
+        sharedModelManager = new ModelManager();
+        log.info("CQL ModelManager initialized successfully");
+    }
 
     /**
-     * Creates a LibraryManager with default compiler options
-     * (EnableLocators, EnableAnnotations, EnableResultTypes).
+     * Creates a LibraryManager with default compiler options.
      */
     public static LibraryManager create(CqlLibraryRepository libraryRepository) {
         return create(libraryRepository, defaultOptions());
@@ -25,25 +45,27 @@ public final class LibraryManagerFactory {
      * Creates a LibraryManager with the given compiler options.
      */
     public static LibraryManager create(CqlLibraryRepository libraryRepository, CqlCompilerOptions options) {
-        ModelManager modelManager = new ModelManager();
-        LibraryManager libraryManager = new LibraryManager(modelManager, options);
+        ModelManager mm = sharedModelManager;
+        if (mm == null) {
+            // Fallback: if called before Spring init (e.g. in tests), create inline
+            log.warn("sharedModelManager not yet initialized, creating inline (thread: {})",
+                    Thread.currentThread().getName());
+            mm = new ModelManager();
+        }
 
-        // Register database provider first so user libraries take precedence
+        LibraryManager libraryManager = new LibraryManager(mm, options);
+
         if (libraryRepository != null) {
             libraryManager.getLibrarySourceLoader()
                     .registerProvider(new DatabaseLibrarySourceProvider(libraryRepository));
         }
 
-        // Register classpath provider to load FHIRHelpers from classpath resources
         libraryManager.getLibrarySourceLoader()
                 .registerProvider(new ClasspathLibrarySourceProvider("cql"));
 
         return libraryManager;
     }
 
-    /**
-     * Builds CqlCompilerOptions from individual flags.
-     */
     public static CqlCompilerOptions buildOptions(
             boolean enableLocators,
             boolean enableAnnotations,

--- a/backend/src/main/java/com/cqlplatform/service/measure/MeasureEvaluationContext.java
+++ b/backend/src/main/java/com/cqlplatform/service/measure/MeasureEvaluationContext.java
@@ -20,6 +20,8 @@ public class MeasureEvaluationContext {
     private final LocalDate periodStart;
     private final LocalDate periodEnd;
     private final int timeoutSeconds;
+    /** Pre-compiled ELM JSON — translated once, reused for all patients. */
+    private final String preCompiledElmJson;
 
     public String getMeasureId() {
         return request.getMeasureId();
@@ -42,6 +44,10 @@ public class MeasureEvaluationContext {
     }
 
     public String getElmJson() {
+        // Prefer pre-compiled ELM (translated once before patient loop)
+        if (preCompiledElmJson != null) {
+            return preCompiledElmJson;
+        }
         return measureDefinition != null ? measureDefinition.getElmJson() : null;
     }
 }

--- a/backend/src/main/java/com/cqlplatform/service/measure/MeasureEvaluationService.java
+++ b/backend/src/main/java/com/cqlplatform/service/measure/MeasureEvaluationService.java
@@ -33,6 +33,7 @@ import static com.cqlplatform.model.measure.PopulationTypeConstants.*;
 public class MeasureEvaluationService {
 
     private final CqlExecutionService cqlExecutionService;
+    private final com.cqlplatform.service.cql.CqlTranslationService cqlTranslationService;
     private final PatientDiscoveryService patientDiscoveryService;
     private final PopulationEvaluator populationEvaluator;
     private final StratifierEvaluator stratifierEvaluator;
@@ -40,11 +41,13 @@ public class MeasureEvaluationService {
 
     public MeasureEvaluationService(
             CqlExecutionService cqlExecutionService,
+            com.cqlplatform.service.cql.CqlTranslationService cqlTranslationService,
             PatientDiscoveryService patientDiscoveryService,
             PopulationEvaluator populationEvaluator,
             StratifierEvaluator stratifierEvaluator,
             MeasureScoreCalculator scoreCalculator) {
         this.cqlExecutionService = cqlExecutionService;
+        this.cqlTranslationService = cqlTranslationService;
         this.patientDiscoveryService = patientDiscoveryService;
         this.populationEvaluator = populationEvaluator;
         this.stratifierEvaluator = stratifierEvaluator;
@@ -87,7 +90,34 @@ public class MeasureEvaluationService {
         MeasureEvaluationContext context = buildContext(request, measureDefinitionId, measureDefinition);
 
         try {
-            // 1. Discover patients
+            // 1. Pre-translate CQL → ELM once (MADiE pattern: translate once, reuse for all patients)
+            if (context.getElmJson() == null && context.getMeasureCql() != null) {
+                long translateStart = System.currentTimeMillis();
+                try {
+                    var translateRequest = new com.cqlplatform.model.CqlTranslationRequest();
+                    translateRequest.setCql(context.getMeasureCql());
+                    var translateResponse = cqlTranslationService.translate(translateRequest);
+                    if (translateResponse.isSuccess() && translateResponse.getElmJson() != null) {
+                        context = MeasureEvaluationContext.builder()
+                                .request(context.getRequest())
+                                .measureDefinition(context.getMeasureDefinition())
+                                .measureDefinitionId(context.getMeasureDefinitionId())
+                                .periodStart(context.getPeriodStart())
+                                .periodEnd(context.getPeriodEnd())
+                                .timeoutSeconds(context.getTimeoutSeconds())
+                                .preCompiledElmJson(translateResponse.getElmJson())
+                                .build();
+                        log.info("Pre-compiled CQL to ELM in {}ms (will reuse for all patients)",
+                                System.currentTimeMillis() - translateStart);
+                    } else {
+                        log.warn("CQL pre-translation failed, will translate per patient");
+                    }
+                } catch (Exception e) {
+                    log.warn("CQL pre-translation failed: {}, will translate per patient", e.getMessage());
+                }
+            }
+
+            // 2. Discover patients
             List<String> patients = patientDiscoveryService.discoverPatients(context);
             if (patients.isEmpty()) {
                 stopTimer(sample);
@@ -95,7 +125,7 @@ public class MeasureEvaluationService {
                 return errorResult(context, patientDiscoveryService.buildNoPatientsMessage(context));
             }
 
-            // 2. Execute CQL per patient and aggregate
+            // 3. Execute CQL per patient and aggregate
             AggregationState state = executeAndAggregate(context, patients);
 
             // 3. Check if all patients failed

--- a/backend/src/main/java/com/cqlplatform/service/measure/PopulationEvaluator.java
+++ b/backend/src/main/java/com/cqlplatform/service/measure/PopulationEvaluator.java
@@ -37,18 +37,47 @@ public class PopulationEvaluator {
 
     /**
      * Aggregates a single patient's CQL results into the running population counts.
+     * Enforces HL7 proportion measure population hierarchy:
+     * <ul>
+     *   <li>Denominator is only counted if Initial Population is true</li>
+     *   <li>Denominator Exclusions only if Denominator is true</li>
+     *   <li>Numerator is only counted if Denominator is true AND not excluded</li>
+     *   <li>Numerator Exclusions only if Numerator is true</li>
+     *   <li>Denominator Exceptions only if Denominator is true but Numerator is false</li>
+     * </ul>
      *
      * @param counts  running population counts (mutated in place)
      * @param results CQL expression results for one patient
      */
     public void aggregatePatientResults(Map<String, Integer> counts,
                                         Map<String, CqlExecutionResponse.ExpressionResult> results) {
-        for (String key : counts.keySet()) {
-            Integer count = extractPopulationCount(results, key);
-            if (count != null && count > 0) {
-                counts.put(key, counts.get(key) + count);
-            }
-        }
+        // Evaluate each population for this patient
+        boolean inInitPop = isPopulationTrue(results, "Initial Population");
+        boolean inDenom = inInitPop && isPopulationTrue(results, "Denominator");
+        boolean denomExcluded = inDenom && isPopulationTrue(results, "Denominator Exclusions");
+        boolean effectiveDenom = inDenom && !denomExcluded;
+        boolean inNumer = effectiveDenom && isPopulationTrue(results, "Numerator");
+        boolean numerExcluded = inNumer && isPopulationTrue(results, "Numerator Exclusions");
+        boolean effectiveNumer = inNumer && !numerExcluded;
+        boolean denomException = effectiveDenom && !effectiveNumer
+                && isPopulationTrue(results, "Denominator Exceptions");
+
+        if (inInitPop) increment(counts, "Initial Population");
+        if (inDenom) increment(counts, "Denominator");
+        if (denomExcluded) increment(counts, "Denominator Exclusions");
+        if (effectiveNumer) increment(counts, "Numerator");
+        if (numerExcluded) increment(counts, "Numerator Exclusions");
+        if (denomException) increment(counts, "Denominator Exceptions");
+    }
+
+    private boolean isPopulationTrue(Map<String, CqlExecutionResponse.ExpressionResult> results,
+                                     String populationName) {
+        Integer count = extractPopulationCount(results, populationName);
+        return count != null && count > 0;
+    }
+
+    private void increment(Map<String, Integer> counts, String key) {
+        counts.computeIfPresent(key, (k, v) -> v + 1);
     }
 
     /**

--- a/backend/src/test/java/com/cqlplatform/service/measure/MeasureEvaluationServiceTest.java
+++ b/backend/src/test/java/com/cqlplatform/service/measure/MeasureEvaluationServiceTest.java
@@ -29,6 +29,9 @@ class MeasureEvaluationServiceTest {
     private CqlExecutionService cqlExecutionService;
 
     @Mock
+    private com.cqlplatform.service.cql.CqlTranslationService cqlTranslationService;
+
+    @Mock
     private FhirDataProviderService fhirDataProviderService;
 
     private PatientDiscoveryService patientDiscoveryService;
@@ -44,7 +47,7 @@ class MeasureEvaluationServiceTest {
         scoreCalculator = new MeasureScoreCalculator();
         stratifierEvaluator = new StratifierEvaluator(populationEvaluator, scoreCalculator);
         measureService = new MeasureEvaluationService(
-                cqlExecutionService, patientDiscoveryService,
+                cqlExecutionService, cqlTranslationService, patientDiscoveryService,
                 populationEvaluator, stratifierEvaluator, scoreCalculator);
         ReflectionTestUtils.setField(measureService, "defaultPeriodStart", "");
         ReflectionTestUtils.setField(measureService, "defaultPeriodEnd", "");


### PR DESCRIPTION
## 變更說明

修正 CQL 引擎在 eQCM 評估時的多個問題，並優化評估效能。

### 1. CQL 翻譯錯誤不再靜默吞掉
### 2. Worker 執行緒 Class Loader 修復
### 3. Population 從屬關係 (220% score bug)
### 4. 效能優化：預翻譯 CQL（參考 MADiE 模式）

## 關聯 Issue

Closes #150
Related: #166 #167 #168

## 測試紀錄

- [x] MeasureEvaluationServiceTest 9 個測試通過
- [x] CqlExecutionIntegrationTest 15 個測試通過

## 風險評估

中 — 影響 CQL 執行和 eQCM 評估的核心邏輯

## IEC 62304 / ISO 14971 追溯

| 項目 | 內容 |
|------|------|
| 需求 Issue | #150 |
| 設計 Issue | #166 |
| 風險 Issue | #167 |
| 驗證 Issue | #168 |
| 安全性等級 | B |

🤖 Generated with [Claude Code](https://claude.com/claude-code)