### PR TITLE
fix: episode-based CV Measure Population preserves list return

### DIFF
--- a/backend/src/main/java/com/cqlplatform/service/authoring/ExpressionCqlEngine.java
+++ b/backend/src/main/java/com/cqlplatform/service/authoring/ExpressionCqlEngine.java
@@ -31,6 +31,8 @@ public class ExpressionCqlEngine {
         public final Map<String, String> baseElementNameIndex;
         public final Map<String, String> parameterNameIndex;
         public final List<String> warnings = new ArrayList<>();
+        /** When true, list-returning expressions keep their list type instead of being wrapped in exists(). */
+        public boolean preserveListReturn = false;
 
         public BuildContext(List<Map<String, Object>> baseElements, List<Map<String, Object>> parameters) {
             this.baseElements = baseElements;
@@ -186,7 +188,8 @@ public class ExpressionCqlEngine {
         }
 
         String finalReturnType = getFinalReturnType(element, modifiers);
-        if (finalReturnType != null && finalReturnType.startsWith("list_of_")) {
+        if (finalReturnType != null && finalReturnType.startsWith("list_of_")
+                && !ctx.preserveListReturn) {
             expr = String.format("exists(%s)", expr);
         }
 

--- a/backend/src/main/java/com/cqlplatform/service/ecqm/EcqmCqlBuilder.java
+++ b/backend/src/main/java/com/cqlplatform/service/ecqm/EcqmCqlBuilder.java
@@ -147,13 +147,19 @@ public class EcqmCqlBuilder {
                 }
 
                 // Population defines in canonical order
+                boolean isCvEpisode = EcqmConstants.SCORING_CONTINUOUS_VARIABLE.equals(scoringType) && isEpisodeBased;
                 for (String popKey : EcqmConstants.ALL_POPULATION_KEYS) {
                     if (dualIp && "initial-population".equals(popKey)) continue;
                     Object popTree = populations.get(popKey);
                     if (popTree == null) continue;
                     String defineName = EcqmConstants.POPULATION_KEY_TO_DEFINE.get(popKey);
                     if (defineName == null) continue;
+                    // Episode-based CV: Measure Population should return resource list, not boolean
+                    if (isCvEpisode && "measure-population".equals(popKey)) {
+                        ctx.preserveListReturn = true;
+                    }
                     appendPopulationDefine(block, defineName + suffix, (Map<String, Object>) popTree, ctx);
+                    ctx.preserveListReturn = false;
                 }
 
                 // Observations (continuous variable)


### PR DESCRIPTION
## Summary
- 修正 episode-based continuous-variable 的 Measure Population 被 `exists()` 包裝成 boolean 的問題
- 新增 `BuildContext.preserveListReturn` 旗標，episode-based CV 的 measure-population 保留 list 回傳
- 修復 CQL 驗證錯誤：`Could not resolve call to operator Measure Observation with signature (System.Boolean)`

## 關聯 Issue
修正 #174 合併後 episode-based CV measure CQL 驗證失敗

## 測試紀錄
- [x] Backend compile 通過
- [x] EcqmCqlBuilderTest + ExpressionCqlEngineTest 通過

## 風險評估
安全性等級：A — CQL 產生邏輯修正，不影響 proportion/ratio 路徑

🤖 Generated with [Claude Code](https://claude.com/claude-code)