### PR TITLE
feat: empty required populations inherit from parent in eCQM CQL

### DIFF
--- a/backend/src/main/java/com/cqlplatform/model/ecqm/EcqmConstants.java
+++ b/backend/src/main/java/com/cqlplatform/model/ecqm/EcqmConstants.java
@@ -76,6 +76,16 @@ public final class EcqmConstants {
     );
 
     /**
+     * When a required population has an empty expression tree, it inherits from its parent.
+     * e.g. empty Denominator → references "Initial Population".
+     */
+    public static final Map<String, String> POPULATION_PARENT = Map.of(
+            DENOMINATOR, INITIAL_POPULATION,
+            NUMERATOR, DENOMINATOR,
+            MEASURE_POPULATION, INITIAL_POPULATION
+    );
+
+    /**
      * All population keys that can appear in a population group, in CMS canonical order.
      */
     public static final List<String> ALL_POPULATION_KEYS = List.of(

--- a/backend/src/main/java/com/cqlplatform/service/ecqm/EcqmCqlBuilder.java
+++ b/backend/src/main/java/com/cqlplatform/service/ecqm/EcqmCqlBuilder.java
@@ -150,12 +150,25 @@ public class EcqmCqlBuilder {
 
                 // Population defines in canonical order
                 boolean isCvEpisode = EcqmConstants.SCORING_CONTINUOUS_VARIABLE.equals(scoringType) && isEpisodeBased;
+                List<String> requiredPops = EcqmConstants.REQUIRED_POPULATIONS.getOrDefault(scoringType, List.of());
                 for (String popKey : EcqmConstants.ALL_POPULATION_KEYS) {
                     if (dualIp && "initial-population".equals(popKey)) continue;
-                    Object popTree = populations.get(popKey);
-                    if (popTree == null) continue;
                     String defineName = EcqmConstants.POPULATION_KEY_TO_DEFINE.get(popKey);
                     if (defineName == null) continue;
+
+                    Object popTree = populations.get(popKey);
+                    boolean isEmpty = popTree == null || isEmptyTree((Map<String, Object>) popTree);
+
+                    if (isEmpty) {
+                        // Required populations with empty trees inherit from parent population
+                        String parentDefine = EcqmConstants.POPULATION_PARENT.get(defineName);
+                        if (parentDefine != null && requiredPops.contains(defineName)) {
+                            block.append(String.format("define \"%s%s\":\n  \"%s%s\"\n\n",
+                                    defineName, suffix, parentDefine, suffix));
+                        }
+                        continue;
+                    }
+
                     // Episode-based CV: Measure Population should return resource list, not boolean
                     if (isCvEpisode && "measure-population".equals(popKey)) {
                         ctx.preserveListReturn = true;
@@ -245,6 +258,13 @@ public class EcqmCqlBuilder {
     }
 
     // ── Private helpers ──────────────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    private boolean isEmptyTree(Map<String, Object> tree) {
+        if (tree == null) return true;
+        List<Map<String, Object>> children = (List<Map<String, Object>>) tree.get("childInstances");
+        return children == null || children.isEmpty();
+    }
 
     private void appendPopulationDefine(StringBuilder block, String defineName,
             Map<String, Object> tree, BuildContext ctx) {


### PR DESCRIPTION
## Summary
- 空的必要族群自動引用其父族群：
  - 空分母 → `define "Denominator": "Initial Population"`
  - 空分子 → `define "Numerator": "Denominator"`
  - 空測量族群 → `define "Measure Population": "Initial Population"`
- 遵循 CMS eCQM 標準模式

## 關聯 Issue
延續 #177 eCQM 改善

## 測試紀錄
- [x] Backend compile + EcqmCqlBuilderTest 通過

## 風險評估
安全性等級：A

## IEC 62304 / ISO 14971 追溯
| 項目 | 內容 |
|------|------|
| 軟體需求 | 空的必要族群自動繼承父族群 |
| 設計規格 | POPULATION_PARENT map + isEmptyTree check |
| 風險分析 | 低風險 — CQL 產生邏輯增強 |
| 驗證紀錄 | EcqmCqlBuilderTest 通過 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)