### PR TITLE
fix: strip non-ASCII from CQL string literals

### DIFF
--- a/backend/src/main/java/com/cqlplatform/service/authoring/ExpressionCqlEngine.java
+++ b/backend/src/main/java/com/cqlplatform/service/authoring/ExpressionCqlEngine.java
@@ -880,7 +880,16 @@ public class ExpressionCqlEngine {
 
     public String escapeCqlString(String value) {
         if (value == null) return "";
-        return value.replace("\\", "\\\\").replace("'", "\\'");
+        String cleaned = stripNonAscii(value);
+        return cleaned.replace("\\", "\\\\").replace("'", "\\'");
+    }
+
+    /** Strips non-ASCII characters and cleans up residual empty parentheses/whitespace. */
+    private String stripNonAscii(String value) {
+        return value.replaceAll("[^\\x00-\\x7F]", "")
+                .replaceAll("\\(\\s*\\)", "")
+                .replaceAll("\\s{2,}", " ")
+                .trim();
     }
 
     /**
@@ -891,11 +900,7 @@ public class ExpressionCqlEngine {
      */
     public String escapeCqlIdentifier(String value) {
         if (value == null) return "";
-        // Strip non-ASCII characters and clean up residual whitespace/parentheses
-        String ascii = value.replaceAll("[^\\x00-\\x7F]", "")
-                .replaceAll("\\(\\s*\\)", "")   // remove empty parentheses left after stripping
-                .replaceAll("\\s{2,}", " ")      // collapse multiple spaces
-                .trim();
+        String ascii = stripNonAscii(value);
         return ascii.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 


### PR DESCRIPTION
## Summary
- `escapeCqlString()` 也去除非 ASCII（修正 value set URI 中的中文）
- 提取共用 `stripNonAscii()` 方法

## 關聯 Issue
延續 #180 CQL 中文清除

## 測試紀錄
- [x] Backend compile 通過

## 風險評估
安全性等級：A

## IEC 62304 / ISO 14971 追溯
| 項目 | 內容 |
|------|------|
| 軟體需求 | CQL 字串不含非 ASCII |
| 設計規格 | stripNonAscii 共用方法 |
| 風險分析 | 低風險 |
| 驗證紀錄 | 編譯通過 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)