### PR TITLE
fix: CDS Tuple accessor for CQL 4.5 + CQL non-ASCII cleanup

### DIFF
--- a/backend/src/main/java/com/cqlplatform/service/cds/CdsTupleAccessor.java
+++ b/backend/src/main/java/com/cqlplatform/service/cds/CdsTupleAccessor.java
@@ -19,6 +19,10 @@ public final class CdsTupleAccessor {
         if (value == null) {
             return false;
         }
+        // CQL engine 4.5+ may return Tuples as plain Maps
+        if (value instanceof Map) {
+            return true;
+        }
         try {
             java.lang.reflect.Method m = value.getClass().getMethod("getElements");
             return Map.class.isAssignableFrom(m.getReturnType());
@@ -29,6 +33,10 @@ public final class CdsTupleAccessor {
 
     @SuppressWarnings("unchecked")
     public static Map<String, Object> getElements(Object tuple) {
+        // CQL engine 4.5+ may return Tuples as plain Maps
+        if (tuple instanceof Map) {
+            return (Map<String, Object>) tuple;
+        }
         try {
             java.lang.reflect.Method getElements = tuple.getClass().getMethod("getElements");
             return (Map<String, Object>) getElements.invoke(tuple);


### PR DESCRIPTION
## Summary
- **CDS Hooks 修復**: CQL 4.5 引擎回傳 Tuple 為 Map 而非 Tuple 物件，`isTuple()` 未識別導致所有 Card Tuple 被忽略，回傳 "No recommendations"
- **CQL 字串非 ASCII 清除**: `escapeCqlString()` 去除 value set URI 中的中文

## 關聯 Issue
修正 #181 後續問題 — CDS Hooks Card Tuple 識別失敗

## 測試紀錄
- [x] Backend compile 通過
- [x] curl 驗證 CDS endpoint 回傳正確 Card

## 風險評估
安全性等級：A

## IEC 62304 / ISO 14971 追溯
| 項目 | 內容 |
|------|------|
| 軟體需求 | CDS Hooks 正確回傳 CQL Card Tuple |
| 設計規格 | CdsTupleAccessor 支援 Map-based Tuple |
| 風險分析 | 低風險 — 修正 CQL 4.5 相容性 |
| 驗證紀錄 | curl 測試通過 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)