### PR TITLE
fix: support externalCqlElement in backend validator + CQL generator

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -118,9 +118,28 @@
       "Bash(powershell.exe -Command \"Get-ChildItem ''$env:USERPROFILE\\\\.vscode\\\\extensions'' -Directory -Filter ''*java*'' -ErrorAction SilentlyContinue | Select-Object Name\")",
       "Bash(powershell.exe -Command \"Get-Process *code* -ErrorAction SilentlyContinue | Select-Object Name,Path | Format-Table -AutoSize\")",
       "Bash(powershell.exe -Command \"Test-Path ''$env:LOCALAPPDATA\\\\Programs\\\\Microsoft VS Code''; Test-Path ''$env:USERPROFILE\\\\.vscode''; Get-ChildItem ''$env:USERPROFILE\\\\.vscode'' -ErrorAction SilentlyContinue | Select-Object Name\")",
-      "Bash(\"/c/Program Files/apache-maven-3.9.9/bin/mvn\" -f backend/pom.xml compile -q 2>&1)",
-      "Bash(\"/c/Program Files/apache-maven-3.9.9/bin/mvn\" -f backend/pom.xml test -Dtest=\"CqlExecutionIntegrationTest,CqlPipelineIntegrationTest\" -pl .)",
-      "Bash(git mv:*)"
+      "Bash(git checkout:*)",
+      "Bash(powershell.exe -Command \"Get-Command gh -ErrorAction SilentlyContinue | Select-Object Source\")",
+      "Bash(grep '\"\"@mui/material\"\"' package.json)",
+      "Read(//c/Program Files/GitHub CLI//**)",
+      "Read(//c/Users/alumi/scoop/shims/**)",
+      "Read(//c/Users/alumi/AppData/Local/Programs/**)",
+      "Bash(powershell.exe -Command \"where.exe gh\")",
+      "Bash(powershell.exe -Command \"\\(Get-Command gh\\).Source\")",
+      "Bash(powershell.exe -Command \"where.exe gh 2>\\\\$null; Test-Path 'C:\\\\Program Files\\\\GitHub CLI\\\\gh.exe'; Test-Path 'C:\\\\Users\\\\alumi\\\\AppData\\\\Local\\\\GitHub CLI\\\\gh.exe'\")",
+      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" pr view 115 --json title,state,statusCheckRollup --jq '{title: .title, state: .state, checks: [.statusCheckRollup[] | {name: .name, status: .status, conclusion: .conclusion}]}')",
+      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" pr checks 115 2>&1)",
+      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" run view 23464791181 --log-failed)",
+      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" run list --branch feat/patient-generator --limit 3 2>&1)",
+      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" run list --branch feat/patient-generator --limit 2 2>&1)",
+      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" run view 23465303580 --log-failed)",
+      "Bash(node:*)",
+      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" run view 23468350317 --log-failed)",
+      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" run view 23468502542 --log)",
+      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" pr merge 115 --merge --subject \"feat: add TW Core IG patient generator + SMART Backend Services EHR auth \\(#PAT-059 #PAT-060\\)\" 2>&1)",
+      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" pr view 115 --json state,mergedAt --jq '{state: .state, mergedAt: .mergedAt}' 2>&1)",
+      "Bash(ssh:*)",
+      "Bash(\"/c/Users/alumi/apache-maven-3.9.12/bin/mvn\" -f backend/pom.xml test -Dtest=\"ExpressionCqlEngineTest,EcqmControllerTest,ExpressionTreeValidatorTest\" -q)"
     ]
   }
 }

--- a/backend/src/main/java/com/cqlplatform/service/authoring/ExpressionCqlEngine.java
+++ b/backend/src/main/java/com/cqlplatform/service/authoring/ExpressionCqlEngine.java
@@ -209,6 +209,20 @@ public class ExpressionCqlEngine {
                 }
                 break;
             }
+            case "externalCqlElement": {
+                // Library definition reference from LibraryDefinitionPicker (eCQM integration)
+                String alias = getFieldValue(fields, "alias", "");
+                String defName = getFieldValue(fields, "definitionName", "");
+                if (alias != null && !alias.isEmpty() && defName != null && !defName.isEmpty()) {
+                    expr = String.format("\"%s\".\"%s\"", escapeCqlIdentifier(alias), escapeCqlIdentifier(defName));
+                } else if (defName != null && !defName.isEmpty()) {
+                    expr = String.format("\"%s\"", escapeCqlIdentifier(defName));
+                } else {
+                    ctx.warn(String.format("External CQL element '%s' has no definition name", elementName));
+                    expr = "null /* missing library definition */";
+                }
+                break;
+            }
             case "arithmeticExpression": {
                 String operator = getFieldValue(fields, "operator", "+");
                 // Validate operator to prevent injection
@@ -621,6 +635,23 @@ public class ExpressionCqlEngine {
                             safeLibName, escapeCqlString(libVersion), safeLibName);
                 } else {
                     includeStmt = String.format("include %s called %s", safeLibName, safeLibName);
+                }
+                includes.add(includeStmt);
+            }
+        } else if ("externalCqlElement".equals(type)) {
+            List<Map<String, Object>> extFields = (List<Map<String, Object>>) node.get("fields");
+            String libName = getFieldValue(extFields, "libraryName", null);
+            String libVersion = getFieldValue(extFields, "libraryVersion", null);
+            String alias = getFieldValue(extFields, "alias", null);
+            if (libName != null && !libName.isEmpty()) {
+                String safeLibName = libName.replaceAll("[^a-zA-Z0-9_]", "_");
+                String called = (alias != null && !alias.isEmpty()) ? alias : safeLibName;
+                String includeStmt;
+                if (libVersion != null && !libVersion.isEmpty()) {
+                    includeStmt = String.format("include %s version '%s' called %s",
+                            safeLibName, escapeCqlString(libVersion), called);
+                } else {
+                    includeStmt = String.format("include %s called %s", safeLibName, called);
                 }
                 includes.add(includeStmt);
             }

--- a/backend/src/main/java/com/cqlplatform/service/authoring/TemplateService.java
+++ b/backend/src/main/java/com/cqlplatform/service/authoring/TemplateService.java
@@ -24,7 +24,7 @@ public class TemplateService {
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final Set<String> BUILTIN_REFERENCE_TYPES = Set.of(
             "baseElement", "baseElementRef", "parameterRef", "externalCqlRef",
-            "arithmeticExpression", "And", "Or", "Union", "Intersect");
+            "externalCqlElement", "arithmeticExpression", "And", "Or", "Union", "Intersect");
 
     private List<FormTemplateCategory> categories = new ArrayList<>();
     private Set<String> knownElementTypes = new HashSet<>();

--- a/docs/CHANGE_LOG.md
+++ b/docs/CHANGE_LOG.md
@@ -9,6 +9,7 @@
 
 | ID | 類型 | 日期 | 範圍 | 標題 | 備註 | Commit |
 |-----|------|------|------|------|------|--------|
+| BUG-104 | 🐛 fix | 2026-04-02 | 後端（eCQM 驗證/CQL 產生） | eCQM 程式庫定義儲存失敗 — LibraryDefinitionPicker 建立 `externalCqlElement` 元素但後端驗證器不認識此型別，導致 ValidationException；新增 TemplateService BUILTIN_REFERENCE_TYPES + ExpressionCqlEngine CQL 產生/include 收集 | TemplateService、ExpressionCqlEngine | |
 | PAT-065 | ✨ feature | 2026-03-29 | 前端（CQL 程式庫） | CQL Library Management UI — 完整複製 MADiE 程式庫系統：4-Tab 列表(All/Mine/Shared/Public)+搜尋排序、5-Tab 工作區(CQL Editor/Metadata/Dependencies/History/Sharing)、auto-save+Ctrl+S、版本管理(Major/Minor/Draft/Compare)、FHIR/CQL 匯入匯出、分享/轉移、依賴分析、eCQM LibraryDefinitionPicker 整合、i18n EN+zh-TW | 15 新檔案、+3234 行 | [`fbbb4a0`](../../commit/fbbb4a0) |
 | BUG-103 | 🐛 fix | 2026-03-29 | 後端（CQL 執行） | CV 觀察值序列化遺失 — `toSerializable` 未處理 HAPI FHIR `DecimalType`，回傳 `String` 而非 `BigDecimal`，導致 `extractObservationValues` 無法識別為 `Number`，聚合結果為空；新增 `PrimitiveType<?>` 處理，解包為原始 Java 型別 | CqlExecutionService | [`de38f71`](../../commit/de38f71) |
 | BUG-102 | 🐛 fix | 2026-03-29 | 後端（CQL 執行） | Bulk fetch 遺漏 FunctionRef 內的 Retrieve 類型 — `collectRetrieveTypes` 遇到 `FunctionRef`（繼承 `ExpressionRef`）時跳過，導致 `C3F.Verified([Observation])` 中的 Observation 未被提取，bulk fetch 不拉 Observation 資料，CV 量測 Measure Population 恆為 0 | CqlExecutionService | [`befa1d7`](../../commit/befa1d7) |


### PR DESCRIPTION
## 變更說明

修復 eCQM 使用程式庫定義 (`LibraryDefinitionPicker`) 時儲存失敗的問題。

## 關聯 Issue

Fixes #193

## 問題根因

Commit `fbbb4a0` (PAT-065) 新增 `LibraryDefinitionPicker`，前端建立 `externalCqlElement` 類型元素，但後端未做對應更新：
- `EcqmExpressionTreeValidator` 不認識 `externalCqlElement` → 儲存時拋 `ValidationException`
- `ExpressionCqlEngine` 無法產生 CQL 表達式與 include 宣告

## 修正內容

| 檔案 | 變更 |
|------|------|
| `TemplateService.java` | 新增 `externalCqlElement` 至 `BUILTIN_REFERENCE_TYPES` |
| `ExpressionCqlEngine.java` | 新增 CQL 產生邏輯（alias + definitionName → `"A"."MeetsInclusionCriteria"`） |
| `ExpressionCqlEngine.java` | 新增 include 收集邏輯（libraryName + libraryVersion + alias → `include ASCVD version '1.0.0' called A`） |

## 測試紀錄

- 163 個 ExpressionCqlEngine 測試全數通過
- VM 後端日誌確認錯誤重現

## 風險評估

- 低風險：僅新增元素類型支援，不影響既有 `externalCqlRef` 行為
- 無資料庫變更

### IEC 62304 追溯

| 項目 | 內容 |
|------|------|
| 軟體需求 | #193 |
| 安全性等級 | A（顯示修正，無臨床決策影響） |

### ISO 14971 風險評估

| 項目 | 內容 |
|------|------|
| 危害情境 | 無（修復既有功能缺陷） |
| 殘餘風險 | 可接受 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)