### PR TITLE
fix: dashboard quality report separates scoring types + trend improvements

### DIFF
--- a/backend/src/main/java/com/cqlplatform/model/measure/QualityReport.java
+++ b/backend/src/main/java/com/cqlplatform/model/measure/QualityReport.java
@@ -33,5 +33,6 @@ public class QualityReport {
         private Double score;
         private String status; // above_target, below_target, warning, critical
         private Double targetThreshold;
+        private String scoringType; // proportion, ratio, continuous-variable, cohort
     }
 }

--- a/backend/src/main/java/com/cqlplatform/service/measure/DashboardService.java
+++ b/backend/src/main/java/com/cqlplatform/service/measure/DashboardService.java
@@ -83,12 +83,31 @@ public class DashboardService {
 
         return reports.stream()
                 .map(r -> EnhancedDashboardData.TrendDataPoint.builder()
-                        .period((r.getPeriodStart() != null ? r.getPeriodStart() : "?") + " to " + (r.getPeriodEnd() != null ? r.getPeriodEnd() : "?"))
+                        .period(formatPeriodLabel(r.getPeriodStart(), r.getPeriodEnd()))
                         .measureName(r.getMeasureName())
                         .measureId(r.getMeasureDefinitionId())
                         .score(r.getMeasureScore())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Format period label concisely based on the date range.
+     * Same month → "Jan 2026", same year → "Jan-Mar 2026", cross-year → "Dec 25-Jan 26"
+     */
+    private String formatPeriodLabel(LocalDate start, LocalDate end) {
+        if (start == null && end == null) return "?";
+        if (start == null) return end.toString();
+        if (end == null) return start.toString();
+        String sMonth = start.getMonth().name().substring(0, 3);
+        String eMonth = end.getMonth().name().substring(0, 3);
+        if (start.getYear() == end.getYear() && start.getMonth() == end.getMonth()) {
+            return sMonth + " " + start.getYear();
+        }
+        if (start.getYear() == end.getYear()) {
+            return sMonth + "-" + eMonth + " " + start.getYear();
+        }
+        return sMonth + " " + (start.getYear() % 100) + "-" + eMonth + " " + (end.getYear() % 100);
     }
 
     @Transactional(readOnly = true)
@@ -156,16 +175,23 @@ public class DashboardService {
 
         List<QualityReport.MeasureScoreSummary> scoreSummaries = new ArrayList<>();
         int above = 0, below = 0;
-        double totalScore = 0;
-        int scored = 0;
+        // Only average proportion-compatible measures (proportion, ratio, cohort)
+        // Continuous-variable scores represent raw values (e.g., HbA1c 5.6),
+        // not percentages, so mixing them with proportion scores is meaningless.
+        double proportionTotal = 0;
+        int proportionScored = 0;
 
         for (MeasureDefinitionEntity m : measures) {
             Double score = latestScores.get(m.getId());
             Double target = targetMap.get(m.getId());
+            String scoring = m.getScoringType() != null ? m.getScoringType() : "proportion";
             String status = "no_data";
             if (score != null) {
-                scored++;
-                totalScore += score;
+                boolean isProportionLike = !"continuous-variable".equals(scoring);
+                if (isProportionLike) {
+                    proportionScored++;
+                    proportionTotal += score;
+                }
                 if (target != null) {
                     status = score >= target ? "above_target" : "below_target";
                     if (score >= target) above++;
@@ -178,6 +204,7 @@ public class DashboardService {
                     .score(score)
                     .status(status)
                     .targetThreshold(target)
+                    .scoringType(scoring)
                     .build());
         }
 
@@ -188,7 +215,7 @@ public class DashboardService {
                 .totalMeasures(measures.size())
                 .measuresAboveTarget(above)
                 .measuresBelowTarget(below)
-                .averageScore(scored > 0 ? totalScore / scored : 0)
+                .averageScore(proportionScored > 0 ? proportionTotal / proportionScored : 0)
                 .measureScores(scoreSummaries)
                 .departmentAverages(computeDepartmentScores())
                 .build();

--- a/backend/src/main/java/com/cqlplatform/service/measure/MeasureEvaluationService.java
+++ b/backend/src/main/java/com/cqlplatform/service/measure/MeasureEvaluationService.java
@@ -447,7 +447,8 @@ public class MeasureEvaluationService {
 
         return MeasureEvaluationResult.builder()
                 .measureId(context.getMeasureId())
-                .measureName(context.getMeasureId())
+                .measureName(context.getMeasureDefinition() != null && context.getMeasureDefinition().getName() != null
+                        ? context.getMeasureDefinition().getName() : context.getMeasureId())
                 .status(EvaluationStatusConstants.COMPLETE)
                 .periodStart(context.getPeriodStart())
                 .periodEnd(context.getPeriodEnd())
@@ -509,7 +510,8 @@ public class MeasureEvaluationService {
 
         return MeasureEvaluationResult.builder()
                 .measureId(context.getMeasureId())
-                .measureName(context.getMeasureId())
+                .measureName(context.getMeasureDefinition() != null && context.getMeasureDefinition().getName() != null
+                        ? context.getMeasureDefinition().getName() : context.getMeasureId())
                 .status(EvaluationStatusConstants.COMPLETE)
                 .periodStart(context.getPeriodStart())
                 .periodEnd(context.getPeriodEnd())

--- a/docs/CHANGE_LOG.md
+++ b/docs/CHANGE_LOG.md
@@ -9,6 +9,7 @@
 
 | ID | 類型 | 日期 | 範圍 | 標題 | 備註 | Commit |
 |-----|------|------|------|------|------|--------|
+| BUG-105 | 🐛 fix | 2026-04-03 | 全端（品質指標儀表板） | 品質報告混合計分類型平均 + 趨勢圖難理解 — 品質報告把 proportion（百分比）和 continuous-variable（原始數值如 HbA1c 5.6）混在一起平均，改為只平均比例型指標；趨勢圖 X 軸標籤過長改為簡短格式，修正 measureName 儲存 ID 而非名稱 | DashboardService、MeasureEvaluationService、QualityReportPanel | |
 | BUG-104 | 🐛 fix | 2026-04-02 | 後端（eCQM 驗證/CQL 產生） | eCQM 程式庫定義儲存失敗 — LibraryDefinitionPicker 建立 `externalCqlElement` 元素但後端驗證器不認識此型別，導致 ValidationException；新增 TemplateService BUILTIN_REFERENCE_TYPES + ExpressionCqlEngine CQL 產生/include 收集 | TemplateService、ExpressionCqlEngine | |
 | PAT-065 | ✨ feature | 2026-03-29 | 前端（CQL 程式庫） | CQL Library Management UI — 完整複製 MADiE 程式庫系統：4-Tab 列表(All/Mine/Shared/Public)+搜尋排序、5-Tab 工作區(CQL Editor/Metadata/Dependencies/History/Sharing)、auto-save+Ctrl+S、版本管理(Major/Minor/Draft/Compare)、FHIR/CQL 匯入匯出、分享/轉移、依賴分析、eCQM LibraryDefinitionPicker 整合、i18n EN+zh-TW | 15 新檔案、+3234 行 | [`fbbb4a0`](../../commit/fbbb4a0) |
 | BUG-103 | 🐛 fix | 2026-03-29 | 後端（CQL 執行） | CV 觀察值序列化遺失 — `toSerializable` 未處理 HAPI FHIR `DecimalType`，回傳 `String` 而非 `BigDecimal`，導致 `extractObservationValues` 無法識別為 `Number`，聚合結果為空；新增 `PrimitiveType<?>` 處理，解包為原始 Java 型別 | CqlExecutionService | [`de38f71`](../../commit/de38f71) |

--- a/frontend/src/components/dashboard/QualityReportPanel.tsx
+++ b/frontend/src/components/dashboard/QualityReportPanel.tsx
@@ -17,6 +17,13 @@ interface QualityReportPanelProps {
   report: QualityReportData | null
 }
 
+function formatScore(score: number | undefined | null, scoringType?: string, naLabel = 'N/A'): string {
+  if (score == null) return naLabel
+  // Continuous-variable scores are raw values (e.g., HbA1c 5.6), not percentages
+  if (scoringType === 'continuous-variable') return score.toFixed(1)
+  return `${score.toFixed(1)}%`
+}
+
 export default function QualityReportPanel({ report }: QualityReportPanelProps) {
   const { t } = useTranslation('measures')
   const { t: tCommon } = useTranslation('common')
@@ -71,7 +78,7 @@ export default function QualityReportPanel({ report }: QualityReportPanelProps) 
               <TableRow key={ms.measureId}>
                 <TableCell>{ms.measureName}</TableCell>
                 <TableCell align="right">
-                  {ms.score != null ? `${ms.score.toFixed(1)}%` : tCommon('notAvailable')}
+                  {formatScore(ms.score, ms.scoringType, tCommon('notAvailable'))}
                 </TableCell>
                 <TableCell align="right">
                   {ms.targetThreshold != null ? `${ms.targetThreshold}%` : '-'}

--- a/frontend/src/locales/en/measures.json
+++ b/frontend/src/locales/en/measures.json
@@ -38,7 +38,7 @@
     "departmentScores": "Department Scores",
     "qualityReport": "Quality Report",
     "noReportData": "No report data available",
-    "averageScore": "Average Score",
+    "averageScore": "Proportion Avg",
     "aboveTarget": "Above Target",
     "belowTarget": "Below Target",
     "alerts": "Alerts",

--- a/frontend/src/locales/zh-TW/measures.json
+++ b/frontend/src/locales/zh-TW/measures.json
@@ -38,7 +38,7 @@
     "departmentScores": "部門分數",
     "qualityReport": "品質報告",
     "noReportData": "無報告資料",
-    "averageScore": "平均分數",
+    "averageScore": "比例指標平均",
     "aboveTarget": "達標",
     "belowTarget": "未達標",
     "alerts": "警示",

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1153,6 +1153,7 @@ export interface MeasureScoreSummary {
   score?: number
   status: string
   targetThreshold?: number
+  scoringType?: string
 }
 
 // Department types


### PR DESCRIPTION
## 變更說明

修復品質指標儀表板兩個問題：品質報告混合不同計分類型計算平均值、分數趨勢圖難以理解。

## 關聯 Issue

Fixes #194

## 修正內容

### 品質報告 — 不再混合計分類型
- `DashboardService.generateReport()` 只平均 proportion/ratio/cohort 指標，排除 continuous-variable
- `QualityReport.MeasureScoreSummary` 新增 `scoringType` 欄位
- 前端 CV 指標顯示原始數值（如 `5.6`），不加 `%`
- 標籤從「平均分數」改為「比例指標平均」

### 分數趨勢圖 — 改善可讀性
- 期間標籤從 `"2026-01-01 to 2026-12-31"` 改為 `"JAN-DEC 2026"`
- `MeasureEvaluationService` 修正 `.measureName()` 儲存定義名稱而非 ID

## 測試紀錄

- Backend 編譯通過
- Frontend TypeScript 型別檢查通過

## 風險評估

- 低風險：僅影響儀表板顯示邏輯
- 無資料庫變更

### IEC 62304 追溯

| 項目 | 內容 |
|------|------|
| 軟體需求 | #194 |
| 安全性等級 | A |

### ISO 14971 風險評估

| 項目 | 內容 |
|------|------|
| 危害情境 | 無 |
| 殘餘風險 | 可接受 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)