### PR TITLE
feat: CDS Hooks debug mode + structured diagnostics (1-8)

### DIFF
--- a/backend/src/main/java/com/cqlplatform/controller/AdminController.java
+++ b/backend/src/main/java/com/cqlplatform/controller/AdminController.java
@@ -10,6 +10,7 @@ import com.cqlplatform.service.PasswordResetService;
 import com.cqlplatform.service.RefreshTokenService;
 import com.cqlplatform.service.TokenVersionService;
 import com.cqlplatform.service.UserApiKeyService;
+import com.cqlplatform.service.cds.CdsRecentInvocationsService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -31,6 +32,13 @@ public class AdminController {
     private final UserApiKeyService userApiKeyService;
     private final TokenVersionService tokenVersionService;
     private final RefreshTokenService refreshTokenService;
+    private final CdsRecentInvocationsService cdsRecentInvocationsService;
+
+    @GetMapping("/cds/recent-invocations")
+    public ResponseEntity<List<CdsRecentInvocationsService.InvocationRecord>> recentCdsInvocations(
+            @RequestParam(defaultValue = "50") int limit) {
+        return ResponseEntity.ok(cdsRecentInvocationsService.recent(Math.min(Math.max(1, limit), 100)));
+    }
 
     @GetMapping("/users")
     public ResponseEntity<List<UserSummary>> listUsers() {

--- a/backend/src/main/java/com/cqlplatform/controller/CdsHooksController.java
+++ b/backend/src/main/java/com/cqlplatform/controller/CdsHooksController.java
@@ -90,6 +90,8 @@ public class CdsHooksController {
             }
             // Use testData as prefetch, no fhirServer -> forces PrefetchRetrieveProvider
             cdsRequest.setPrefetch(sandboxRequest.getTestData());
+            cdsRequest.setDebugMode(sandboxRequest.isDebugMode());
+            cdsRequest.setDryRun(sandboxRequest.isDryRun());
 
             CdsResponse response = cdsHooksService.invokeService(serviceId, cdsRequest);
             return ResponseEntity.ok(response);

--- a/backend/src/main/java/com/cqlplatform/exception/CdsInvocationException.java
+++ b/backend/src/main/java/com/cqlplatform/exception/CdsInvocationException.java
@@ -1,0 +1,34 @@
+package com.cqlplatform.exception;
+
+import lombok.Getter;
+
+/**
+ * Thrown internally by CdsInvocationService when any phase of CDS invocation fails.
+ * Carries the phase label so the caller can surface structured error info to clients.
+ * Not handled by GlobalExceptionHandler — CdsInvocationService catches this itself
+ * and converts to a CdsResponse with debug info.
+ */
+@Getter
+public class CdsInvocationException extends RuntimeException {
+
+    public enum Phase {
+        PREFETCH_RESOLUTION,
+        PREFETCH_PROVIDER_BUILD,
+        CQL_TRANSLATION,
+        CQL_EXECUTION,
+        CARD_GENERATION,
+        UNKNOWN
+    }
+
+    private final Phase phase;
+
+    public CdsInvocationException(Phase phase, String message, Throwable cause) {
+        super(message, cause);
+        this.phase = phase;
+    }
+
+    public CdsInvocationException(Phase phase, Throwable cause) {
+        super(cause.getMessage(), cause);
+        this.phase = phase;
+    }
+}

--- a/backend/src/main/java/com/cqlplatform/model/CqlExecutionResponse.java
+++ b/backend/src/main/java/com/cqlplatform/model/CqlExecutionResponse.java
@@ -42,6 +42,8 @@ public class CqlExecutionResponse {
         private List<RetrieveTrace> retrieveTraces;
         private long totalTimeMs;
         private Map<String, String> sourceLocators;
+        /** Compiled ELM JSON (only populated when debugMode=true). */
+        private String elmJson;
     }
 
     @Data

--- a/backend/src/main/java/com/cqlplatform/model/cds/CdsRequest.java
+++ b/backend/src/main/java/com/cqlplatform/model/cds/CdsRequest.java
@@ -31,6 +31,12 @@ public class CdsRequest {
 
     private Map<String, Object> prefetch;
 
+    /** When true, response will include DebugTrace and structured error info. */
+    private boolean debugMode = false;
+
+    /** When true, resolve prefetch + check context but skip CQL execution. Implies debugMode. */
+    private boolean dryRun = false;
+
     @Data
     public static class CdsContext {
         @Size(max = 200)

--- a/backend/src/main/java/com/cqlplatform/model/cds/CdsResponse.java
+++ b/backend/src/main/java/com/cqlplatform/model/cds/CdsResponse.java
@@ -1,10 +1,12 @@
 package com.cqlplatform.model.cds;
 
+import com.cqlplatform.model.CqlExecutionResponse;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 @Builder
@@ -12,6 +14,83 @@ import java.util.List;
 public class CdsResponse {
     private List<Card> cards;
     private List<SystemAction> systemActions;
+
+    /** Only populated when the invocation request had debugMode=true. */
+    private CdsDebugInfo debug;
+
+    @Data
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class CdsDebugInfo {
+        /** CQL execution trace (expressions + FHIR retrieves). Null on early-phase failures. */
+        private CqlExecutionResponse.DebugTrace debugTrace;
+
+        /** Structured error info when invocation failed. Null on success. */
+        private CdsErrorInfo error;
+
+        /** Context snapshot — service id, hook, patientId, fhir server etc. */
+        private Map<String, Object> invocationContext;
+
+        /** Per-key prefetch resolution status (template resolution or sandbox testData). */
+        private List<PrefetchStatus> prefetchStatus;
+
+        /** Context/patient binding warnings (non-fatal). */
+        private List<String> contextWarnings;
+
+        /** FHIR server diagnostics when server-backed retrieve is attempted. */
+        private FhirServerDiagnostics fhirServerDiagnostics;
+
+        /** True when the invocation ran in dry-run mode (CQL execution skipped). */
+        private Boolean dryRun;
+
+        /** Resource count by FHIR type available to CQL engine (only populated in dry-run). */
+        private Map<String, Integer> resourcesByType;
+    }
+
+    @Data
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class CdsErrorInfo {
+        /** Phase in which the error occurred (see CdsInvocationException.Phase). */
+        private String phase;
+        /** Simple name of the root exception class. */
+        private String errorType;
+        private String message;
+        /** Top N stack frames (own package preferred). */
+        private List<String> stackTraceSummary;
+    }
+
+    @Data
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class PrefetchStatus {
+        /** Prefetch key (e.g. "Patient", "Conditions"). */
+        private String key;
+        /** "success" / "failed" / "empty" */
+        private String status;
+        /** Resources parsed/resolved for this key. */
+        private Integer count;
+        /** Elapsed milliseconds for this key's resolution. */
+        private Long elapsedMs;
+        /** Error message if status=failed. */
+        private String error;
+        /** Resolved URL if this came from a template (null for sandbox testData). */
+        private String resolvedUrl;
+    }
+
+    @Data
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class FhirServerDiagnostics {
+        private String url;
+        /** "not_attempted" / "success" / "error" */
+        private String status;
+        /** Error category: timeout / network / not_found / unauthorized / server_error / other */
+        private String errorCategory;
+        private String errorMessage;
+        private Integer httpStatus;
+        private Long elapsedMs;
+    }
 
     @Data
     @Builder

--- a/backend/src/main/java/com/cqlplatform/model/cds/CdsSandboxRequest.java
+++ b/backend/src/main/java/com/cqlplatform/model/cds/CdsSandboxRequest.java
@@ -33,4 +33,10 @@ public class CdsSandboxRequest {
     private Map<String, Object> testData;
     private Object draftOrders;
     private Object appointments;
+
+    /** When true, response will include DebugTrace and structured error info. */
+    private boolean debugMode = false;
+
+    /** When true, resolve prefetch + check context but skip CQL execution. Implies debugMode. */
+    private boolean dryRun = false;
 }

--- a/backend/src/main/java/com/cqlplatform/service/cds/CdsInvocationService.java
+++ b/backend/src/main/java/com/cqlplatform/service/cds/CdsInvocationService.java
@@ -1,5 +1,7 @@
 package com.cqlplatform.service.cds;
 
+import com.cqlplatform.exception.CdsInvocationException;
+import com.cqlplatform.exception.CdsInvocationException.Phase;
 import com.cqlplatform.model.CqlExecutionRequest;
 import com.cqlplatform.model.CqlExecutionResponse;
 import com.cqlplatform.model.cds.CdsRequest;
@@ -17,6 +19,9 @@ import org.opencds.cqf.cql.engine.retrieve.RetrieveProvider;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -50,79 +55,124 @@ public class CdsInvocationService {
     @org.springframework.beans.factory.annotation.Autowired(required = false)
     private PrefetchResolver prefetchResolver;
 
+    @org.springframework.beans.factory.annotation.Autowired(required = false)
+    private CdsRecentInvocationsService recentInvocationsService;
+
     /**
      * Invoke a CDS service: execute CQL and generate cards.
      */
     public CdsResponse invoke(CdsHooksService.CdsServiceConfig config, CdsRequest request) {
         String patientId = request.getContext() != null ? request.getContext().getPatientId() : "unknown";
-        log.info("Invoking CDS service: {} for patient: {}", config.getId(), patientId);
+        boolean dryRun = request.isDryRun();
+        boolean debugMode = request.isDebugMode() || dryRun; // dry-run implies debug
+        log.info("Invoking CDS service: {} for patient: {} (debugMode={}, dryRun={})",
+                config.getId(), patientId, debugMode, dryRun);
         if (cdsInvocationCounter != null)
             cdsInvocationCounter.increment();
         Timer.Sample sample = cdsInvocationTimer != null ? Timer.start() : null;
         long startTime = System.currentTimeMillis();
 
+        InvocationDiagnostics diagnostics = new InvocationDiagnostics();
+
         try {
             CqlExecutionRequest execRequest = new CqlExecutionRequest();
             execRequest.setCql(config.getCqlContent());
             execRequest.setPatientId(request.getContext() != null ? request.getContext().getPatientId() : null);
+            execRequest.setDebugMode(debugMode);
 
-            RetrieveProvider prefetchProvider = buildPrefetchProvider(request);
+            RetrieveProvider prefetchProvider = buildPrefetchProviderSafe(request, diagnostics);
 
             // If no prefetch data, try dynamic resolution from prefetch templates
             if (prefetchProvider == null && prefetchResolver != null
                     && config.getPrefetch() != null && !config.getPrefetch().isEmpty()
                     && request.getFhirServer() != null && !request.getFhirServer().isBlank()) {
-                log.info("Attempting dynamic prefetch template resolution for service: {}", config.getId());
-                try {
-                    Map<String, Resource> resolvedResources = prefetchResolver.resolve(config.getPrefetch(), request);
-                    if (!resolvedResources.isEmpty()) {
-                        String pid = request.getContext() != null ? request.getContext().getPatientId() : null;
-                        List<Resource> resources = new ArrayList<>(resolvedResources.values());
-                        // Auto-populate subject references
-                        if (pid != null) {
-                            Reference patRef = new Reference("Patient/" + pid);
-                            for (Resource r : resources) {
-                                ensureSubjectReference(r, patRef);
-                            }
-                        }
-                        prefetchProvider = new PrefetchRetrieveProvider(resources, pid);
-                        log.info("Built prefetch provider from {} resolved templates", resolvedResources.size());
-                    }
-                } catch (Exception e) {
-                    log.warn("Prefetch template resolution failed, falling back to FHIR server: {}", e.getMessage());
-                }
+                prefetchProvider = resolvePrefetchTemplates(config, request, diagnostics);
             }
 
+            // Diagnose FHIR server usage (when prefetch didn't cover everything)
             if (prefetchProvider == null) {
                 String fhirServer = request.getFhirServer();
                 if (fhirServer != null && (fhirServer.contains("/r2/") || fhirServer.contains("/dstu2/"))) {
                     log.warn("Client FHIR server is DSTU2 ({}), falling back to default R4 server", fhirServer);
                     execRequest.setFhirServerUrl(null);
+                    diagnostics.setFhirServerDiagnostics(CdsResponse.FhirServerDiagnostics.builder()
+                            .url(fhirServer).status("not_attempted")
+                            .errorCategory("unsupported_version")
+                            .errorMessage("Client FHIR server is DSTU2; fell back to default R4 server")
+                            .build());
                 } else {
                     execRequest.setFhirServerUrl(fhirServer);
+                    if (fhirServer != null) {
+                        diagnostics.setFhirServerDiagnostics(CdsResponse.FhirServerDiagnostics.builder()
+                                .url(fhirServer).status("attempted").build());
+                    }
                 }
             }
 
-            CqlExecutionResponse execResponse;
-            if (prefetchProvider != null) {
-                // Keep the patientId so the CQL engine can establish a proper Patient
-                // context.  Without a patient context the engine cannot evaluate
-                // Patient-context expressions and all retrieves return empty.
-                execResponse = executionService.executeWithProvider(execRequest, prefetchProvider);
-            } else {
-                execResponse = executionService.execute(execRequest);
+            // Feature 4: context diagnostics (warnings for missing patientId, binding issues)
+            diagnostics.getContextWarnings().addAll(collectContextWarnings(request, prefetchProvider));
+
+            // Feature 8: dry-run short-circuit — skip CQL execution and return diagnostics only
+            if (dryRun) {
+                long elapsed = System.currentTimeMillis() - startTime;
+                if (sample != null && cdsInvocationTimer != null) sample.stop(cdsInvocationTimer);
+                if (recentInvocationsService != null) {
+                    recentInvocationsService.record(CdsRecentInvocationsService.InvocationRecord.builder()
+                            .timestamp(java.time.Instant.now())
+                            .serviceId(config.getId()).hook(config.getHook())
+                            .patientId(patientId).success(true).elapsedMs(elapsed)
+                            .errorPhase("dry_run")
+                            .build());
+                }
+                Map<String, Integer> resourceCounts = (prefetchProvider instanceof PrefetchRetrieveProvider prp)
+                        ? prp.getResourceCountsByType() : Map.of();
+                return CdsResponse.builder()
+                        .cards(List.of())
+                        .debug(toDebugInfo(config, request, diagnostics)
+                                .dryRun(true)
+                                .resourcesByType(resourceCounts)
+                                .build())
+                        .build();
             }
 
-            // Select strategy based on card generation mode
-            CardGenerationStrategy strategy = selectStrategy(config);
-            CdsResponse response = strategy.buildResponse(config, execResponse);
+            CqlExecutionResponse execResponse;
+            try {
+                execResponse = executeCql(execRequest, prefetchProvider);
+                if (diagnostics.getFhirServerDiagnostics() != null
+                        && "attempted".equals(diagnostics.getFhirServerDiagnostics().getStatus())) {
+                    diagnostics.getFhirServerDiagnostics().setStatus("success");
+                }
+            } catch (CdsInvocationException ex) {
+                // Categorize FHIR server error if applicable
+                if (diagnostics.getFhirServerDiagnostics() != null
+                        && "attempted".equals(diagnostics.getFhirServerDiagnostics().getStatus())) {
+                    categorizeFhirServerError(diagnostics.getFhirServerDiagnostics(),
+                            ex.getCause() != null ? ex.getCause() : ex);
+                }
+                throw ex;
+            }
+
+            CdsResponse response = buildCards(config, execResponse);
 
             if (sample != null && cdsInvocationTimer != null)
                 sample.stop(cdsInvocationTimer);
 
+            long elapsed = System.currentTimeMillis() - startTime;
             if (analyticsService != null) {
-                long elapsed = System.currentTimeMillis() - startTime;
                 analyticsService.recordInvocation(config.getId(), elapsed, true);
+            }
+            if (recentInvocationsService != null) {
+                recentInvocationsService.record(CdsRecentInvocationsService.InvocationRecord.builder()
+                        .timestamp(java.time.Instant.now())
+                        .serviceId(config.getId()).hook(config.getHook())
+                        .patientId(patientId).success(true).elapsedMs(elapsed)
+                        .build());
+            }
+
+            if (debugMode) {
+                response.setDebug(toDebugInfo(config, request, diagnostics)
+                        .debugTrace(execResponse.getDebugTrace())
+                        .build());
             }
 
             return response;
@@ -132,16 +182,192 @@ public class CdsInvocationService {
             if (sample != null && cdsInvocationTimer != null)
                 sample.stop(cdsInvocationTimer);
 
+            long elapsed = System.currentTimeMillis() - startTime;
             if (analyticsService != null) {
-                long elapsed = System.currentTimeMillis() - startTime;
                 analyticsService.recordInvocation(config.getId(), elapsed, false);
             }
 
             log.error("CDS service invocation failed", e);
-            return CdsResponse.builder()
-                    .cards(List.of(tupleStrategy.createErrorCard(e.getMessage())))
-                    .build();
+
+            Phase phase = (e instanceof CdsInvocationException cie) ? cie.getPhase() : Phase.UNKNOWN;
+            Throwable root = (e instanceof CdsInvocationException && e.getCause() != null) ? e.getCause() : e;
+
+            if (recentInvocationsService != null) {
+                recentInvocationsService.record(CdsRecentInvocationsService.InvocationRecord.builder()
+                        .timestamp(java.time.Instant.now())
+                        .serviceId(config.getId()).hook(config.getHook())
+                        .patientId(patientId).success(false).elapsedMs(elapsed)
+                        .errorPhase(phase.name().toLowerCase())
+                        .errorMessage(root.getMessage())
+                        .build());
+            }
+
+            CdsResponse.CdsResponseBuilder errorResponse = CdsResponse.builder()
+                    .cards(List.of(tupleStrategy.createErrorCard(root.getMessage())));
+
+            if (debugMode) {
+                errorResponse.debug(toDebugInfo(config, request, diagnostics)
+                        .error(buildErrorInfo(phase, root))
+                        .build());
+            }
+
+            return errorResponse.build();
         }
+    }
+
+    /** Builder for CdsDebugInfo pre-filled with invocation context + diagnostics accumulated so far. */
+    private CdsResponse.CdsDebugInfo.CdsDebugInfoBuilder toDebugInfo(
+            CdsHooksService.CdsServiceConfig config, CdsRequest request, InvocationDiagnostics d) {
+        return CdsResponse.CdsDebugInfo.builder()
+                .invocationContext(buildInvocationContext(config, request))
+                .prefetchStatus(d.getPrefetchStatus().isEmpty() ? null : d.getPrefetchStatus())
+                .contextWarnings(d.getContextWarnings().isEmpty() ? null : d.getContextWarnings())
+                .fhirServerDiagnostics(d.getFhirServerDiagnostics());
+    }
+
+    private RetrieveProvider buildPrefetchProviderSafe(CdsRequest request, InvocationDiagnostics diagnostics) {
+        try {
+            return buildPrefetchProvider(request, diagnostics);
+        } catch (Exception e) {
+            throw new CdsInvocationException(Phase.PREFETCH_PROVIDER_BUILD, e);
+        }
+    }
+
+    private RetrieveProvider resolvePrefetchTemplates(
+            CdsHooksService.CdsServiceConfig config, CdsRequest request, InvocationDiagnostics diagnostics) {
+        log.info("Attempting dynamic prefetch template resolution for service: {}", config.getId());
+        try {
+            PrefetchResolver.ResolutionResult result = prefetchResolver.resolveWithStatus(config.getPrefetch(), request);
+            diagnostics.getPrefetchStatus().addAll(result.getStatuses());
+
+            Map<String, Resource> resolvedResources = result.getResources();
+            if (resolvedResources.isEmpty()) {
+                return null;
+            }
+            String pid = request.getContext() != null ? request.getContext().getPatientId() : null;
+            List<Resource> resources = new ArrayList<>(resolvedResources.values());
+            if (pid != null) {
+                Reference patRef = new Reference("Patient/" + pid);
+                for (Resource r : resources) {
+                    ensureSubjectReference(r, patRef);
+                }
+            }
+            log.info("Built prefetch provider from {} resolved templates", resolvedResources.size());
+            return new PrefetchRetrieveProvider(resources, pid);
+        } catch (Exception e) {
+            log.warn("Prefetch template resolution failed, falling back to FHIR server: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /** Feature 4: collect non-fatal context warnings. */
+    private List<String> collectContextWarnings(CdsRequest request, RetrieveProvider prefetchProvider) {
+        List<String> warnings = new ArrayList<>();
+        if (request.getContext() == null || request.getContext().getPatientId() == null) {
+            warnings.add("context.patientId is missing — CQL Patient-context expressions will evaluate against an unknown patient");
+            return warnings;
+        }
+        String pid = request.getContext().getPatientId();
+        if (prefetchProvider instanceof PrefetchRetrieveProvider prp && !prp.hasPatient(pid)) {
+            warnings.add("No Patient resource with id '" + pid + "' found in prefetch — retrieves filtered by patient context will return empty");
+        }
+        return warnings;
+    }
+
+    /** Feature 5: categorize FHIR server errors for diagnostic clarity. */
+    private static void categorizeFhirServerError(CdsResponse.FhirServerDiagnostics diag, Throwable t) {
+        diag.setStatus("error");
+        diag.setErrorMessage(t.getMessage());
+        String cls = t.getClass().getSimpleName();
+        String msg = t.getMessage() != null ? t.getMessage().toLowerCase() : "";
+        if (cls.contains("Timeout") || msg.contains("timeout") || msg.contains("timed out")) {
+            diag.setErrorCategory("timeout");
+        } else if (cls.contains("ResourceNotFound") || msg.contains("404") || msg.contains("not found")) {
+            diag.setErrorCategory("not_found");
+            diag.setHttpStatus(404);
+        } else if (cls.contains("Unauthorized") || msg.contains("401") || msg.contains("unauthorized")) {
+            diag.setErrorCategory("unauthorized");
+            diag.setHttpStatus(401);
+        } else if (cls.contains("Forbidden") || msg.contains("403")) {
+            diag.setErrorCategory("forbidden");
+            diag.setHttpStatus(403);
+        } else if (cls.contains("Connect") || msg.contains("connection") || msg.contains("unreachable")) {
+            diag.setErrorCategory("network");
+        } else if (msg.contains("500") || cls.contains("InternalServer")) {
+            diag.setErrorCategory("server_error");
+            diag.setHttpStatus(500);
+        } else {
+            diag.setErrorCategory("other");
+        }
+    }
+
+    /** Accumulator for debug diagnostics. */
+    private static class InvocationDiagnostics {
+        @lombok.Getter
+        private final List<CdsResponse.PrefetchStatus> prefetchStatus = new ArrayList<>();
+        @lombok.Getter
+        private final List<String> contextWarnings = new ArrayList<>();
+        @lombok.Setter
+        @lombok.Getter
+        private CdsResponse.FhirServerDiagnostics fhirServerDiagnostics;
+    }
+
+    private CqlExecutionResponse executeCql(CqlExecutionRequest execRequest, RetrieveProvider prefetchProvider) {
+        try {
+            if (prefetchProvider != null) {
+                // Keep the patientId so the CQL engine can establish a proper Patient
+                // context. Without a patient context the engine cannot evaluate
+                // Patient-context expressions and all retrieves return empty.
+                return executionService.executeWithProvider(execRequest, prefetchProvider);
+            }
+            return executionService.execute(execRequest);
+        } catch (Exception e) {
+            Phase phase = looksLikeTranslationError(e) ? Phase.CQL_TRANSLATION : Phase.CQL_EXECUTION;
+            throw new CdsInvocationException(phase, e);
+        }
+    }
+
+    private CdsResponse buildCards(CdsHooksService.CdsServiceConfig config, CqlExecutionResponse execResponse) {
+        try {
+            CardGenerationStrategy strategy = selectStrategy(config);
+            return strategy.buildResponse(config, execResponse);
+        } catch (Exception e) {
+            throw new CdsInvocationException(Phase.CARD_GENERATION, e);
+        }
+    }
+
+    private static boolean looksLikeTranslationError(Throwable t) {
+        String cls = t.getClass().getSimpleName();
+        return cls.contains("Translation") || cls.contains("Parse") || cls.contains("Syntax");
+    }
+
+    private static CdsResponse.CdsErrorInfo buildErrorInfo(Phase phase, Throwable t) {
+        List<String> frames = Arrays.stream(t.getStackTrace())
+                .filter(f -> f.getClassName().startsWith("com.cqlplatform"))
+                .limit(5)
+                .map(StackTraceElement::toString)
+                .toList();
+        return CdsResponse.CdsErrorInfo.builder()
+                .phase(phase.name().toLowerCase())
+                .errorType(t.getClass().getSimpleName())
+                .message(t.getMessage())
+                .stackTraceSummary(frames.isEmpty() ? null : frames)
+                .build();
+    }
+
+    private static Map<String, Object> buildInvocationContext(CdsHooksService.CdsServiceConfig config, CdsRequest request) {
+        Map<String, Object> ctx = new LinkedHashMap<>();
+        ctx.put("serviceId", config.getId());
+        ctx.put("hook", config.getHook());
+        if (request.getContext() != null) {
+            CdsRequest.CdsContext c = request.getContext();
+            if (c.getPatientId() != null) ctx.put("patientId", c.getPatientId());
+            if (c.getUserId() != null) ctx.put("userId", c.getUserId());
+            if (c.getEncounterId() != null) ctx.put("encounterId", c.getEncounterId());
+        }
+        if (request.getFhirServer() != null) ctx.put("fhirServer", request.getFhirServer());
+        if (request.getPrefetch() != null) ctx.put("prefetchKeys", new ArrayList<>(request.getPrefetch().keySet()));
+        return ctx;
     }
 
     private CardGenerationStrategy selectStrategy(CdsHooksService.CdsServiceConfig config) {
@@ -152,7 +378,7 @@ public class CdsInvocationService {
         return tupleStrategy;
     }
 
-    private RetrieveProvider buildPrefetchProvider(CdsRequest request) {
+    private RetrieveProvider buildPrefetchProvider(CdsRequest request, InvocationDiagnostics diagnostics) {
         if (request.getPrefetch() == null || request.getPrefetch().isEmpty()) {
             log.info("No prefetch data provided, will use FHIR server");
             return null;
@@ -163,6 +389,8 @@ public class CdsInvocationService {
         IParser jsonParser = fhirContext.newJsonParser();
 
         for (Map.Entry<String, Object> entry : request.getPrefetch().entrySet()) {
+            long start = System.currentTimeMillis();
+            int before = resources.size();
             try {
                 String json = objectMapper.writeValueAsString(entry.getValue());
                 Resource resource = (Resource) jsonParser.parseResource(json);
@@ -179,8 +407,18 @@ public class CdsInvocationService {
                     resources.add(resource);
                 }
                 log.info("Parsed prefetch key '{}': {}", entry.getKey(), resource.fhirType());
+                diagnostics.getPrefetchStatus().add(CdsResponse.PrefetchStatus.builder()
+                        .key(entry.getKey()).status("success")
+                        .count(resources.size() - before)
+                        .elapsedMs(System.currentTimeMillis() - start)
+                        .build());
             } catch (Exception e) {
                 log.warn("Failed to parse prefetch key '{}': {}", entry.getKey(), e.getMessage());
+                diagnostics.getPrefetchStatus().add(CdsResponse.PrefetchStatus.builder()
+                        .key(entry.getKey()).status("failed").count(0)
+                        .elapsedMs(System.currentTimeMillis() - start)
+                        .error(e.getClass().getSimpleName() + ": " + e.getMessage())
+                        .build());
             }
         }
 

--- a/backend/src/main/java/com/cqlplatform/service/cds/CdsRecentInvocationsService.java
+++ b/backend/src/main/java/com/cqlplatform/service/cds/CdsRecentInvocationsService.java
@@ -1,0 +1,55 @@
+package com.cqlplatform.service.cds;
+
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * In-memory ring buffer of the most recent CDS invocation summaries.
+ * Intended for admin visibility — lightweight alternative to full log aggregation.
+ */
+@Service
+public class CdsRecentInvocationsService {
+
+    private static final int MAX_ENTRIES = 100;
+
+    private final Deque<InvocationRecord> buffer = new LinkedList<>();
+
+    public synchronized void record(InvocationRecord record) {
+        buffer.addFirst(record);
+        while (buffer.size() > MAX_ENTRIES) {
+            buffer.removeLast();
+        }
+    }
+
+    public synchronized List<InvocationRecord> recent(int limit) {
+        int n = Math.min(limit, buffer.size());
+        List<InvocationRecord> out = new ArrayList<>(n);
+        int i = 0;
+        for (InvocationRecord r : buffer) {
+            if (i++ >= n) break;
+            out.add(r);
+        }
+        return out;
+    }
+
+    @Data
+    @Builder
+    public static class InvocationRecord {
+        private Instant timestamp;
+        private String serviceId;
+        private String hook;
+        private String patientId;
+        private boolean success;
+        private long elapsedMs;
+        /** Error phase if failed (e.g. "cql_execution"). */
+        private String errorPhase;
+        private String errorMessage;
+    }
+}

--- a/backend/src/main/java/com/cqlplatform/service/cds/PrefetchResolver.java
+++ b/backend/src/main/java/com/cqlplatform/service/cds/PrefetchResolver.java
@@ -3,14 +3,19 @@ package com.cqlplatform.service.cds;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.client.interceptor.BearerTokenAuthInterceptor;
 import com.cqlplatform.model.cds.CdsRequest;
+import com.cqlplatform.model.cds.CdsResponse;
 import com.cqlplatform.model.cds.CdsServiceDefinition;
 import com.cqlplatform.service.fhir.FhirClientFactory;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Resource;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -39,21 +44,29 @@ public class PrefetchResolver {
     public Map<String, Resource> resolve(
             Map<String, CdsServiceDefinition.PrefetchTemplate> templates,
             CdsRequest request) {
+        return resolveWithStatus(templates, request).getResources();
+    }
+
+    /**
+     * Same as {@link #resolve} but also returns per-key status for debug output.
+     */
+    public ResolutionResult resolveWithStatus(
+            Map<String, CdsServiceDefinition.PrefetchTemplate> templates,
+            CdsRequest request) {
 
         Map<String, Resource> resolved = new HashMap<>();
+        List<CdsResponse.PrefetchStatus> statuses = new ArrayList<>();
         String fhirServer = request.getFhirServer();
 
         if (fhirServer == null || fhirServer.isBlank()) {
             log.warn("No fhirServer URL in request, cannot resolve prefetch templates");
-            return resolved;
+            return new ResolutionResult(resolved, statuses);
         }
 
-        // Build context substitution values
         String patientId = request.getContext() != null ? request.getContext().getPatientId() : null;
         String encounterId = request.getContext() != null ? request.getContext().getEncounterId() : null;
         String userId = request.getContext() != null ? request.getContext().getUserId() : null;
 
-        // Create a FHIR client with the appropriate auth
         IGenericClient client = fhirClientFactory.createClient(fhirServer);
         if (request.getFhirAuthorization() != null && !request.getFhirAuthorization().isBlank()) {
             client.registerInterceptor(new BearerTokenAuthInterceptor(request.getFhirAuthorization()));
@@ -65,32 +78,66 @@ public class PrefetchResolver {
 
             if (queryTemplate == null || queryTemplate.isBlank()) {
                 log.debug("Skipping empty prefetch template for key '{}'", key);
+                statuses.add(CdsResponse.PrefetchStatus.builder()
+                        .key(key).status("empty").count(0).build());
                 continue;
             }
 
-            try {
-                // Substitute context variables
-                String resolvedQuery = substituteTemplate(queryTemplate, patientId, encounterId, userId);
-                log.info("Resolving prefetch template '{}': {} -> {}", key, queryTemplate, resolvedQuery);
+            String resolvedQuery = substituteTemplate(queryTemplate, patientId, encounterId, userId);
+            String resolvedUrl = fhirServer + "/" + resolvedQuery;
+            long start = System.currentTimeMillis();
 
-                // Fetch from FHIR server
+            try {
+                log.info("Resolving prefetch template '{}': {} -> {}", key, queryTemplate, resolvedQuery);
                 Resource resource = client.read()
                         .resource(Resource.class)
-                        .withUrl(fhirServer + "/" + resolvedQuery)
+                        .withUrl(resolvedUrl)
                         .execute();
+
+                long elapsed = System.currentTimeMillis() - start;
+                int count = countResources(resource);
 
                 if (resource != null) {
                     resolved.put(key, resource);
-                    log.info("Resolved prefetch '{}': {}", key, resource.fhirType());
+                    log.info("Resolved prefetch '{}': {} ({} resources)", key, resource.fhirType(), count);
                 }
+                statuses.add(CdsResponse.PrefetchStatus.builder()
+                        .key(key).status("success").count(count)
+                        .elapsedMs(elapsed).resolvedUrl(resolvedUrl).build());
             } catch (Exception e) {
+                long elapsed = System.currentTimeMillis() - start;
                 log.warn("Failed to resolve prefetch template '{}': {}", key, e.getMessage());
+                statuses.add(CdsResponse.PrefetchStatus.builder()
+                        .key(key).status("failed").count(0)
+                        .elapsedMs(elapsed).resolvedUrl(resolvedUrl)
+                        .error(e.getClass().getSimpleName() + ": " + e.getMessage())
+                        .build());
                 // Partial resolution is OK per CDS Hooks spec — skip failed keys
             }
         }
 
         log.info("Resolved {}/{} prefetch templates", resolved.size(), templates.size());
-        return resolved;
+        return new ResolutionResult(resolved, statuses);
+    }
+
+    /** Counts resources inside a Bundle, or 1 for a single resource. */
+    private static int countResources(Resource resource) {
+        if (resource == null) return 0;
+        if (resource instanceof Bundle bundle) {
+            return bundle.hasEntry() ? bundle.getEntry().size() : 0;
+        }
+        return 1;
+    }
+
+    @Getter
+    public static class ResolutionResult {
+        private final Map<String, Resource> resources;
+        private final List<CdsResponse.PrefetchStatus> statuses;
+
+        public ResolutionResult(Map<String, Resource> resources, List<CdsResponse.PrefetchStatus> statuses) {
+            this.resources = resources;
+            this.statuses = statuses;
+        }
     }
 
     /**

--- a/backend/src/main/java/com/cqlplatform/service/cds/PrefetchRetrieveProvider.java
+++ b/backend/src/main/java/com/cqlplatform/service/cds/PrefetchRetrieveProvider.java
@@ -47,6 +47,26 @@ public class PrefetchRetrieveProvider implements RetrieveProvider {
     }
 
     /**
+     * Returns a map of resource type → count for dry-run diagnostics.
+     */
+    public Map<String, Integer> getResourceCountsByType() {
+        Map<String, Integer> counts = new HashMap<>();
+        resourcesByType.forEach((type, list) -> counts.put(type, list.size()));
+        return counts;
+    }
+
+    /**
+     * Checks whether a Patient resource with the given id is present in the prefetch data.
+     * Used by debug-mode context diagnostics.
+     */
+    public boolean hasPatient(String patientId) {
+        if (patientId == null) return false;
+        List<Resource> patients = resourcesByType.get("Patient");
+        if (patients == null) return false;
+        return patients.stream().anyMatch(p -> patientId.equals(p.getIdPart()));
+    }
+
+    /**
      * Merge additional resources (e.g. from draftOrders or resolved prefetch templates)
      * into the existing resource map.
      */

--- a/backend/src/main/java/com/cqlplatform/service/cql/CqlExecutionService.java
+++ b/backend/src/main/java/com/cqlplatform/service/cql/CqlExecutionService.java
@@ -525,6 +525,7 @@ public class CqlExecutionService {
                         .retrieveTraces(tracingProvider != null ? tracingProvider.getTraces() : List.of())
                         .totalTimeMs(executionTime)
                         .sourceLocators(sourceLocators)
+                        .elmJson(elmJson)
                         .build();
             }
 

--- a/backend/src/test/java/com/cqlplatform/service/cds/CdsInvocationServiceTest.java
+++ b/backend/src/test/java/com/cqlplatform/service/cds/CdsInvocationServiceTest.java
@@ -168,6 +168,85 @@ class CdsInvocationServiceTest {
     }
 
     @Test
+    void invoke_debugModeFalse_shouldNotAttachDebug() {
+        CdsHooksService.CdsServiceConfig config = CdsHooksService.CdsServiceConfig.builder()
+                .id("test-svc").title("Svc").cqlContent("library Test version '1.0'\ndefine X: true")
+                .build();
+
+        when(executionService.execute(any())).thenReturn(CqlExecutionResponse.builder()
+                .success(true).results(new LinkedHashMap<>()).build());
+        when(tupleStrategy.buildResponse(any(), any())).thenReturn(CdsResponse.builder()
+                .cards(List.of(CdsResponse.Card.builder().summary("OK").build())).build());
+
+        CdsRequest request = new CdsRequest();
+        CdsRequest.CdsContext ctx = new CdsRequest.CdsContext();
+        ctx.setPatientId("p1");
+        request.setContext(ctx);
+        request.setDebugMode(false);
+
+        CdsResponse response = invocationService.invoke(config, request);
+
+        assertThat(response.getDebug()).isNull();
+    }
+
+    @Test
+    void invoke_debugModeTrue_success_shouldAttachDebugTraceAndContext() {
+        CdsHooksService.CdsServiceConfig config = CdsHooksService.CdsServiceConfig.builder()
+                .id("svc-1").hook("patient-view").title("Svc")
+                .cqlContent("library Test version '1.0'\ndefine X: true")
+                .build();
+
+        CqlExecutionResponse.DebugTrace trace = CqlExecutionResponse.DebugTrace.builder()
+                .totalTimeMs(42).build();
+        when(executionService.execute(any())).thenReturn(CqlExecutionResponse.builder()
+                .success(true).results(new LinkedHashMap<>()).debugTrace(trace).build());
+        when(tupleStrategy.buildResponse(any(), any())).thenReturn(CdsResponse.builder()
+                .cards(List.of(CdsResponse.Card.builder().summary("OK").build())).build());
+
+        CdsRequest request = new CdsRequest();
+        CdsRequest.CdsContext ctx = new CdsRequest.CdsContext();
+        ctx.setPatientId("p1");
+        ctx.setUserId("u1");
+        request.setContext(ctx);
+        request.setDebugMode(true);
+
+        CdsResponse response = invocationService.invoke(config, request);
+
+        assertThat(response.getDebug()).isNotNull();
+        assertThat(response.getDebug().getDebugTrace()).isSameAs(trace);
+        assertThat(response.getDebug().getInvocationContext()).containsEntry("serviceId", "svc-1");
+        assertThat(response.getDebug().getInvocationContext()).containsEntry("hook", "patient-view");
+        assertThat(response.getDebug().getInvocationContext()).containsEntry("patientId", "p1");
+        assertThat(response.getDebug().getError()).isNull();
+    }
+
+    @Test
+    void invoke_debugModeTrue_executionFails_shouldAttachErrorInfoWithPhase() {
+        CdsHooksService.CdsServiceConfig config = CdsHooksService.CdsServiceConfig.builder()
+                .id("svc-err").title("Err Svc").cqlContent("library Test version '1.0'\ndefine X: true")
+                .build();
+
+        when(executionService.execute(any())).thenThrow(new RuntimeException("boom"));
+        when(tupleStrategy.createErrorCard("boom")).thenReturn(CdsResponse.Card.builder()
+                .summary("CDS Service Error").detail("boom").indicator("warning").build());
+
+        CdsRequest request = new CdsRequest();
+        CdsRequest.CdsContext ctx = new CdsRequest.CdsContext();
+        ctx.setPatientId("p1");
+        request.setContext(ctx);
+        request.setDebugMode(true);
+
+        CdsResponse response = invocationService.invoke(config, request);
+
+        assertThat(response.getCards()).hasSize(1);
+        assertThat(response.getDebug()).isNotNull();
+        assertThat(response.getDebug().getError()).isNotNull();
+        assertThat(response.getDebug().getError().getPhase()).isEqualTo("cql_execution");
+        assertThat(response.getDebug().getError().getErrorType()).isEqualTo("RuntimeException");
+        assertThat(response.getDebug().getError().getMessage()).isEqualTo("boom");
+    }
+
+    @Test
     void invoke_planDefinitionModeWithNullJson_shouldFallbackToTupleStrategy() {
         CdsHooksService.CdsServiceConfig config = CdsHooksService.CdsServiceConfig.builder()
                 .id("test-svc")

--- a/docs/CHANGE_LOG.md
+++ b/docs/CHANGE_LOG.md
@@ -9,6 +9,7 @@
 
 | ID | 類型 | 日期 | 範圍 | 標題 | 備註 | Commit |
 |-----|------|------|------|------|------|--------|
+| PAT-062 | ✨ feature | 2026-04-16 | 全端（CDS Hooks 除錯） | CDS Hook Debug Mode + 結構化診斷 — 8 合 1 除錯套件：Sandbox/Invoke 支援 debug mode（DebugPanel 顯示 expression/retrieve traces）、phase-wrapped 錯誤（phase + errorType + stack summary）、prefetch per-key 狀態、context 診斷警告、FHIR server 錯誤分類、compiled ELM viewer、admin 最近調用紀錄（ring buffer 100 筆）、dry-run 模式（跳過 CQL 執行） | CdsResponse.CdsDebugInfo, CdsInvocationService, CdsRecentInvocationsService, CdsDebugPanel, RecentInvocationsPanel | |
 | PAT-061 | ✨ feature | 2026-04-13 | 全端（CDS Hooks） | CDS Hook Context Requirements — 依 CDS Hooks 規範為 6 種 hook 類型加入必要 context 欄位驗證（patient-view 需 userId+patientId、order-select 需 selections+draftOrders 等）；後端驗證+discovery 回應帶 contextFields；前端動態渲染 context 欄位與 object tabs；新增 appointment-book 的 appointments 支援 | HookContextRequirements、CdsHooksService、SandboxPanel、InvokeServicePanel、ManageServicesPanel | |
 | BUG-105 | 🐛 fix | 2026-04-03 | 全端（品質指標儀表板） | 品質報告混合計分類型平均 + 趨勢圖難理解 — 品質報告把 proportion（百分比）和 continuous-variable（原始數值如 HbA1c 5.6）混在一起平均，改為只平均比例型指標；趨勢圖 X 軸標籤過長改為簡短格式，修正 measureName 儲存 ID 而非名稱 | DashboardService、MeasureEvaluationService、QualityReportPanel | |
 | BUG-104 | 🐛 fix | 2026-04-02 | 後端（eCQM 驗證/CQL 產生） | eCQM 程式庫定義儲存失敗 — LibraryDefinitionPicker 建立 `externalCqlElement` 元素但後端驗證器不認識此型別，導致 ValidationException；新增 TemplateService BUILTIN_REFERENCE_TYPES + ExpressionCqlEngine CQL 產生/include 收集 | TemplateService、ExpressionCqlEngine | |

--- a/frontend/src/components/cds/CdsDebugPanel.tsx
+++ b/frontend/src/components/cds/CdsDebugPanel.tsx
@@ -1,0 +1,294 @@
+import { useState } from 'react'
+import {
+  Box,
+  Typography,
+  Stack,
+  Alert,
+  AlertTitle,
+  Chip,
+  Collapse,
+  IconButton,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@mui/material'
+import {
+  KeyboardArrowDown as ExpandIcon,
+  KeyboardArrowUp as CollapseIcon,
+  BugReport as DebugIcon,
+  CheckCircle as SuccessIcon,
+  Error as ErrorIcon,
+  RadioButtonUnchecked as EmptyIcon,
+} from '@mui/icons-material'
+import { useTranslation } from 'react-i18next'
+import DebugPanel from '../execution/DebugPanel'
+import type { CdsDebugInfo, PrefetchStatus, FhirServerDiagnostics } from '../../types'
+
+interface Props {
+  debug: CdsDebugInfo
+}
+
+function phaseColor(phase: string): 'error' | 'warning' | 'info' {
+  if (phase === 'cql_execution' || phase === 'cql_translation') return 'error'
+  if (phase === 'prefetch_resolution' || phase === 'prefetch_provider_build') return 'warning'
+  return 'info'
+}
+
+function prefetchStatusIcon(status: string) {
+  if (status === 'success') return <SuccessIcon fontSize="small" color="success" />
+  if (status === 'failed') return <ErrorIcon fontSize="small" color="error" />
+  return <EmptyIcon fontSize="small" color="disabled" />
+}
+
+function fhirServerSeverity(status: string): 'error' | 'warning' | 'info' | 'success' {
+  if (status === 'error') return 'error'
+  if (status === 'not_attempted') return 'warning'
+  if (status === 'success') return 'success'
+  return 'info'
+}
+
+interface PrefetchSectionProps {
+  statuses: PrefetchStatus[]
+}
+
+function PrefetchSection({ statuses }: PrefetchSectionProps) {
+  const { t } = useTranslation('cds')
+  return (
+    <Box>
+      <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600, color: 'secondary.main' }}>
+        {t('debug.prefetchStatus')}
+      </Typography>
+      <TableContainer component={Paper} variant="outlined">
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell sx={{ width: 32 }} />
+              <TableCell>{t('debug.prefetchKey')}</TableCell>
+              <TableCell>{t('debug.prefetchCount')}</TableCell>
+              <TableCell>{t('debug.prefetchTime')}</TableCell>
+              <TableCell>{t('debug.prefetchDetail')}</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {statuses.map((s) => (
+              <TableRow key={s.key} hover>
+                <TableCell>{prefetchStatusIcon(s.status)}</TableCell>
+                <TableCell>
+                  <Typography variant="body2" sx={{ fontFamily: 'monospace', fontWeight: 600 }}>
+                    {s.key}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Chip size="small" label={s.count ?? 0} variant="outlined" />
+                </TableCell>
+                <TableCell>
+                  <Typography variant="caption">{s.elapsedMs != null ? `${s.elapsedMs}ms` : '-'}</Typography>
+                </TableCell>
+                <TableCell>
+                  {s.error && (
+                    <Typography variant="caption" color="error" sx={{ fontFamily: 'monospace' }}>
+                      {s.error}
+                    </Typography>
+                  )}
+                  {s.resolvedUrl && !s.error && (
+                    <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
+                      {s.resolvedUrl}
+                    </Typography>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  )
+}
+
+interface FhirDiagProps {
+  diag: FhirServerDiagnostics
+}
+
+function FhirServerSection({ diag }: FhirDiagProps) {
+  const { t } = useTranslation('cds')
+  return (
+    <Alert severity={fhirServerSeverity(diag.status)} icon={false}>
+      <AlertTitle>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Chip size="small" color={fhirServerSeverity(diag.status)} label={t(`debug.fhirStatus.${diag.status}`, { defaultValue: diag.status })} />
+          <Typography variant="body2" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
+            {diag.url}
+          </Typography>
+        </Stack>
+      </AlertTitle>
+      {diag.errorCategory && (
+        <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 0.5 }}>
+          <Chip size="small" variant="outlined" label={t(`debug.fhirCategory.${diag.errorCategory}`, { defaultValue: diag.errorCategory })} />
+          {diag.httpStatus && <Chip size="small" variant="outlined" label={`HTTP ${diag.httpStatus}`} />}
+          {diag.elapsedMs != null && <Typography variant="caption">{diag.elapsedMs}ms</Typography>}
+        </Stack>
+      )}
+      {diag.errorMessage && (
+        <Typography variant="body2" sx={{ mt: 1, fontFamily: 'monospace' }}>
+          {diag.errorMessage}
+        </Typography>
+      )}
+    </Alert>
+  )
+}
+
+export default function CdsDebugPanel({ debug }: Props) {
+  const { t } = useTranslation('cds')
+  const [stackOpen, setStackOpen] = useState(false)
+  const [contextOpen, setContextOpen] = useState(false)
+
+  const { error, debugTrace, invocationContext, prefetchStatus, contextWarnings, fhirServerDiagnostics, dryRun, resourcesByType } = debug
+
+  return (
+    <Stack spacing={2} sx={{ mt: 2 }}>
+      <Stack direction="row" spacing={1} alignItems="center">
+        <DebugIcon fontSize="small" color="secondary" />
+        <Typography variant="subtitle2" sx={{ fontWeight: 600, color: 'secondary.main' }}>
+          {t('debug.title')}
+        </Typography>
+      </Stack>
+
+      {error && (
+        <Alert severity={phaseColor(error.phase)} icon={false}>
+          <AlertTitle>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <Chip
+                size="small"
+                color={phaseColor(error.phase)}
+                label={t(`debug.phase.${error.phase}`, { defaultValue: error.phase })}
+              />
+              <Typography component="span" variant="body2" sx={{ fontFamily: 'monospace' }}>
+                {error.errorType}
+              </Typography>
+            </Stack>
+          </AlertTitle>
+          <Typography variant="body2" sx={{ mt: 1 }}>
+            {error.message}
+          </Typography>
+
+          {error.stackTraceSummary && error.stackTraceSummary.length > 0 && (
+            <Box sx={{ mt: 1 }}>
+              <Stack direction="row" alignItems="center" spacing={0.5}>
+                <IconButton size="small" onClick={() => setStackOpen(!stackOpen)}>
+                  {stackOpen ? <CollapseIcon fontSize="small" /> : <ExpandIcon fontSize="small" />}
+                </IconButton>
+                <Typography variant="caption" color="text.secondary">
+                  {t('debug.stackTrace')}
+                </Typography>
+              </Stack>
+              <Collapse in={stackOpen} timeout="auto" unmountOnExit>
+                <Paper variant="outlined" sx={{ p: 1, mt: 0.5, bgcolor: 'background.default' }}>
+                  <Box component="pre" sx={{ m: 0, fontSize: '0.75rem', overflowX: 'auto' }}>
+                    {error.stackTraceSummary.join('\n')}
+                  </Box>
+                </Paper>
+              </Collapse>
+            </Box>
+          )}
+        </Alert>
+      )}
+
+      {dryRun && (
+        <Alert severity="warning" icon={false}>
+          <AlertTitle>{t('debug.dryRunTitle')}</AlertTitle>
+          <Typography variant="body2">{t('debug.dryRunDescription')}</Typography>
+        </Alert>
+      )}
+
+      {resourcesByType && Object.keys(resourcesByType).length > 0 && (
+        <Box>
+          <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600, color: 'secondary.main' }}>
+            {t('debug.resourcesByType')}
+          </Typography>
+          <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+            {Object.entries(resourcesByType).map(([type, count]) => (
+              <Chip key={type} size="small" variant="outlined" label={`${type}: ${count}`} />
+            ))}
+          </Stack>
+        </Box>
+      )}
+
+      {contextWarnings && contextWarnings.length > 0 && (
+        <Alert severity="warning" icon={false}>
+          <AlertTitle>{t('debug.contextWarnings')}</AlertTitle>
+          <Box component="ul" sx={{ m: 0, pl: 2 }}>
+            {contextWarnings.map((w, i) => (
+              <li key={i}>
+                <Typography variant="body2">{w}</Typography>
+              </li>
+            ))}
+          </Box>
+        </Alert>
+      )}
+
+      {fhirServerDiagnostics && <FhirServerSection diag={fhirServerDiagnostics} />}
+
+      {prefetchStatus && prefetchStatus.length > 0 && <PrefetchSection statuses={prefetchStatus} />}
+
+      {invocationContext && Object.keys(invocationContext).length > 0 && (
+        <Box>
+          <Stack direction="row" alignItems="center" spacing={0.5}>
+            <IconButton size="small" onClick={() => setContextOpen(!contextOpen)}>
+              {contextOpen ? <CollapseIcon fontSize="small" /> : <ExpandIcon fontSize="small" />}
+            </IconButton>
+            <Typography variant="caption" color="text.secondary">
+              {t('debug.invocationContext')}
+            </Typography>
+          </Stack>
+          <Collapse in={contextOpen} timeout="auto" unmountOnExit>
+            <Paper variant="outlined" sx={{ p: 1, mt: 0.5, bgcolor: 'background.default' }}>
+              <Box component="pre" sx={{ m: 0, fontSize: '0.75rem', overflowX: 'auto' }}>
+                {JSON.stringify(invocationContext, null, 2)}
+              </Box>
+            </Paper>
+          </Collapse>
+        </Box>
+      )}
+
+      {debugTrace && (debugTrace.expressionTraces.length > 0 || debugTrace.retrieveTraces.length > 0) && (
+        <DebugPanel trace={debugTrace} />
+      )}
+
+      {debugTrace?.elmJson && <ElmSection elmJson={debugTrace.elmJson} />}
+    </Stack>
+  )
+}
+
+function ElmSection({ elmJson }: { elmJson: string }) {
+  const { t } = useTranslation('cds')
+  const [open, setOpen] = useState(false)
+  let pretty = elmJson
+  try {
+    pretty = JSON.stringify(JSON.parse(elmJson), null, 2)
+  } catch {
+    // keep as-is
+  }
+  return (
+    <Box>
+      <Stack direction="row" alignItems="center" spacing={0.5}>
+        <IconButton size="small" onClick={() => setOpen(!open)}>
+          {open ? <CollapseIcon fontSize="small" /> : <ExpandIcon fontSize="small" />}
+        </IconButton>
+        <Typography variant="caption" color="text.secondary">
+          {t('debug.compiledElm')}
+        </Typography>
+      </Stack>
+      <Collapse in={open} timeout="auto" unmountOnExit>
+        <Paper variant="outlined" sx={{ p: 1, mt: 0.5, bgcolor: 'background.default', maxHeight: 400, overflow: 'auto' }}>
+          <Box component="pre" sx={{ m: 0, fontSize: '0.7rem' }}>
+            {pretty}
+          </Box>
+        </Paper>
+      </Collapse>
+    </Box>
+  )
+}

--- a/frontend/src/components/cds/CdsPanel.tsx
+++ b/frontend/src/components/cds/CdsPanel.tsx
@@ -1,18 +1,23 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
+import type { RootState } from '../../store'
 
 import { Paper, Typography, Tabs, Tab } from '@mui/material'
-import { Analytics as AnalyticsIcon, VpnKey as KeyIcon } from '@mui/icons-material'
+import { Analytics as AnalyticsIcon, VpnKey as KeyIcon, History as HistoryIcon } from '@mui/icons-material'
 import TabPanel, { a11yProps } from '../common/TabPanel'
 import InvokeServicePanel from './InvokeServicePanel'
 import ManageServicesPanel from './ManageServicesPanel'
 import AnalyticsPanel from './AnalyticsPanel'
 import SandboxPanel from './SandboxPanel'
 import ApiKeyManager from './ApiKeyManager'
+import RecentInvocationsPanel from './RecentInvocationsPanel'
 
 export default function CdsPanel() {
   const [tabValue, setTabValue] = useState(0)
   const { t } = useTranslation('cds')
+  const userRole = useSelector((state: RootState) => state.auth.user?.role)
+  const isAdmin = userRole === 'ADMIN' || userRole === 'DEPARTMENT_ADMIN'
 
   return (
     <Paper sx={{ p: 2, height: '100%', overflow: 'auto' }}>
@@ -26,6 +31,9 @@ export default function CdsPanel() {
         <Tab label={t('panel.tabAnalytics')} icon={<AnalyticsIcon />} iconPosition="start" {...a11yProps(2, 'cds')} />
         <Tab label={t('panel.tabSandbox')} {...a11yProps(3, 'cds')} />
         <Tab label={t('panel.tabApiKeys')} icon={<KeyIcon />} iconPosition="start" {...a11yProps(4, 'cds')} />
+        {isAdmin && (
+          <Tab label={t('panel.tabRecent')} icon={<HistoryIcon />} iconPosition="start" {...a11yProps(5, 'cds')} />
+        )}
       </Tabs>
 
       <TabPanel value={tabValue} index={0} prefix="cds" sx={{ pt: 2 }}>
@@ -43,6 +51,11 @@ export default function CdsPanel() {
       <TabPanel value={tabValue} index={4} prefix="cds" sx={{ pt: 2 }}>
         <ApiKeyManager />
       </TabPanel>
+      {isAdmin && (
+        <TabPanel value={tabValue} index={5} prefix="cds" sx={{ pt: 2 }}>
+          <RecentInvocationsPanel />
+        </TabPanel>
+      )}
     </Paper>
   )
 }

--- a/frontend/src/components/cds/InvokeServicePanel.tsx
+++ b/frontend/src/components/cds/InvokeServicePanel.tsx
@@ -28,13 +28,17 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
+  Switch,
+  FormControlLabel,
 } from '@mui/material'
 import {
   Info as InfoIcon,
   Warning as WarningIcon,
   Error as ErrorIcon,
   CheckCircle as CheckIcon,
+  BugReport as DebugIcon,
 } from '@mui/icons-material'
+import CdsDebugPanel from './CdsDebugPanel'
 import { alpha } from '@mui/material/styles'
 import {
   useCdsServices,
@@ -88,6 +92,7 @@ export default function InvokeServicePanel() {
   const [fhirServer, setFhirServer] = useState(FHIR_SERVER_PRESETS[0].url)
   const [fhirServerError, setFhirServerError] = useState<string | null>(null)
   const [cdsResponse, setCdsResponse] = useState<CdsResponse | null>(null)
+  const [debugMode, setDebugMode] = useState(false)
   const [overrideDialogOpen, setOverrideDialogOpen] = useState(false)
   const [overrideCardUuid, setOverrideCardUuid] = useState('')
   const [overrideReason, setOverrideReason] = useState('')
@@ -141,6 +146,7 @@ export default function InvokeServicePanel() {
           hookInstance: generateId(),
           fhirServer,
           context,
+          debugMode,
         },
       })
       setCdsResponse(response)
@@ -274,13 +280,34 @@ export default function InvokeServicePanel() {
         />
       ))}
 
-      <GradientButton
-        onClick={handleInvoke}
-        disabled={!selectedService || invokeMutation.isPending}
-        startIcon={invokeMutation.isPending ? <CircularProgress size={20} color="inherit" /> : null}
-      >
-        {invokeMutation.isPending ? t('invoke.invoking') : t('invoke.invokeButton')}
-      </GradientButton>
+      <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between">
+        <FormControlLabel
+          control={
+            <Switch
+              size="small"
+              checked={debugMode}
+              onChange={(e) => setDebugMode(e.target.checked)}
+            />
+          }
+          label={
+            <Stack direction="row" spacing={0.5} alignItems="center">
+              <DebugIcon sx={{ fontSize: 16, color: debugMode ? 'secondary.main' : 'text.secondary' }} />
+              <Typography variant="body2" color={debugMode ? 'secondary.main' : 'text.secondary'}>
+                {t('sandbox.debugMode')}
+              </Typography>
+            </Stack>
+          }
+        />
+        <GradientButton
+          onClick={handleInvoke}
+          disabled={!selectedService || invokeMutation.isPending}
+          startIcon={invokeMutation.isPending ? <CircularProgress size={20} color="inherit" /> : null}
+        >
+          {invokeMutation.isPending ? t('invoke.invoking') : t('invoke.invokeButton')}
+        </GradientButton>
+      </Stack>
+
+      {cdsResponse?.debug && <CdsDebugPanel debug={cdsResponse.debug} />}
 
       <Divider />
 

--- a/frontend/src/components/cds/RecentInvocationsPanel.tsx
+++ b/frontend/src/components/cds/RecentInvocationsPanel.tsx
@@ -1,0 +1,127 @@
+import { useQuery } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import {
+  Alert,
+  Chip,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+  Stack,
+  Button,
+  CircularProgress,
+} from '@mui/material'
+import { Refresh as RefreshIcon } from '@mui/icons-material'
+import { api } from '../../api/client'
+
+interface InvocationRecord {
+  timestamp: string
+  serviceId: string
+  hook: string
+  patientId: string
+  success: boolean
+  elapsedMs: number
+  errorPhase?: string
+  errorMessage?: string
+}
+
+export default function RecentInvocationsPanel() {
+  const { t } = useTranslation('cds')
+
+  const { data, isLoading, isError, refetch, isFetching } = useQuery<InvocationRecord[]>({
+    queryKey: ['cds-recent-invocations'],
+    queryFn: () =>
+      api.get<InvocationRecord[]>('/admin/cds/recent-invocations?limit=100').then((r) => r.data),
+    refetchInterval: 10_000,
+  })
+
+  if (isLoading) return <CircularProgress />
+  if (isError) return <Alert severity="error">{t('recentInvocations.loadError')}</Alert>
+
+  const records = data ?? []
+
+  return (
+    <Stack spacing={1}>
+      <Stack direction="row" justifyContent="space-between" alignItems="center">
+        <Typography variant="subtitle2">
+          {t('recentInvocations.total', { count: records.length })}
+        </Typography>
+        <Button
+          size="small"
+          startIcon={isFetching ? <CircularProgress size={14} /> : <RefreshIcon fontSize="small" />}
+          onClick={() => refetch()}
+          disabled={isFetching}
+        >
+          {t('recentInvocations.refresh')}
+        </Button>
+      </Stack>
+
+      <TableContainer component={Paper} variant="outlined">
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>{t('recentInvocations.time')}</TableCell>
+              <TableCell>{t('recentInvocations.service')}</TableCell>
+              <TableCell>{t('recentInvocations.hook')}</TableCell>
+              <TableCell>{t('recentInvocations.patient')}</TableCell>
+              <TableCell>{t('recentInvocations.status')}</TableCell>
+              <TableCell>{t('recentInvocations.duration')}</TableCell>
+              <TableCell>{t('recentInvocations.detail')}</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {records.map((r, i) => (
+              <TableRow key={`${r.timestamp}-${i}`} hover>
+                <TableCell>
+                  <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
+                    {new Date(r.timestamp).toLocaleString()}
+                  </Typography>
+                </TableCell>
+                <TableCell>{r.serviceId}</TableCell>
+                <TableCell>
+                  <Chip size="small" label={r.hook} variant="outlined" />
+                </TableCell>
+                <TableCell>
+                  <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
+                    {r.patientId}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Chip
+                    size="small"
+                    color={r.success ? 'success' : 'error'}
+                    label={r.success ? t('recentInvocations.success') : t('recentInvocations.failed')}
+                  />
+                </TableCell>
+                <TableCell>{r.elapsedMs}ms</TableCell>
+                <TableCell>
+                  {r.errorPhase && (
+                    <Chip size="small" variant="outlined" label={t(`debug.phase.${r.errorPhase}`, { defaultValue: r.errorPhase })} />
+                  )}
+                  {r.errorMessage && (
+                    <Typography variant="caption" color="error" sx={{ ml: 1, fontFamily: 'monospace' }}>
+                      {r.errorMessage}
+                    </Typography>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+            {records.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={7} align="center">
+                  <Typography variant="body2" color="text.secondary">
+                    {t('recentInvocations.empty')}
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Stack>
+  )
+}

--- a/frontend/src/components/cds/SandboxPanel.tsx
+++ b/frontend/src/components/cds/SandboxPanel.tsx
@@ -30,6 +30,7 @@ import {
   ListSubheader,
   IconButton,
   Tooltip,
+  Switch,
 } from '@mui/material'
 import {
   ViewModule as BuilderIcon,
@@ -38,7 +39,9 @@ import {
   Save as SaveIcon,
   RestartAlt as ResetIcon,
   Delete as DeleteIcon,
+  BugReport as DebugIcon,
 } from '@mui/icons-material'
+import CdsDebugPanel from './CdsDebugPanel'
 import {
   useCdsServices,
   useSandboxInvoke,
@@ -153,6 +156,8 @@ function SandboxPanelInner() {
   const [sandboxResponse, setSandboxResponse] = useState<CdsResponse | null>(null)
   const [dataTab, setDataTab] = useState(0)
   const [objectFieldJsons, setObjectFieldJsons] = useState<Record<string, string>>(DEFAULT_OBJECT_VALUES)
+  const [debugMode, setDebugMode] = useState(false)
+  const [dryRun, setDryRun] = useState(false)
 
   // Critical card queue state
   const [criticalQueue, setCriticalQueue] = useState<CdsCard[]>([])
@@ -421,6 +426,8 @@ function SandboxPanelInner() {
           context,
           testData,
           ...objectContext,
+          debugMode,
+          dryRun,
         },
       })
       setSandboxResponse(response)
@@ -650,17 +657,55 @@ function SandboxPanelInner() {
         )}
       </Box>
 
-      <GradientButton
-        onClick={handleSandboxInvoke}
-        disabled={!selectedService || sandboxMutation.isPending}
-        startIcon={sandboxMutation.isPending ? <CircularProgress size={20} color="inherit" /> : null}
-      >
-        {sandboxMutation.isPending ? t('sandbox.invoking') : t('sandbox.invokeButton')}
-      </GradientButton>
+      <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between">
+        <Stack direction="row" spacing={1}>
+          <FormControlLabel
+            control={
+              <Switch
+                size="small"
+                checked={debugMode}
+                onChange={(e) => setDebugMode(e.target.checked)}
+                disabled={dryRun}
+              />
+            }
+            label={
+              <Stack direction="row" spacing={0.5} alignItems="center">
+                <DebugIcon sx={{ fontSize: 16, color: debugMode ? 'secondary.main' : 'text.secondary' }} />
+                <Typography variant="body2" color={debugMode ? 'secondary.main' : 'text.secondary'}>
+                  {t('sandbox.debugMode')}
+                </Typography>
+              </Stack>
+            }
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                size="small"
+                checked={dryRun}
+                onChange={(e) => setDryRun(e.target.checked)}
+              />
+            }
+            label={
+              <Typography variant="body2" color={dryRun ? 'warning.main' : 'text.secondary'}>
+                {t('sandbox.dryRun')}
+              </Typography>
+            }
+          />
+        </Stack>
+        <GradientButton
+          onClick={handleSandboxInvoke}
+          disabled={!selectedService || sandboxMutation.isPending}
+          startIcon={sandboxMutation.isPending ? <CircularProgress size={20} color="inherit" /> : null}
+        >
+          {sandboxMutation.isPending ? t('sandbox.invoking') : (dryRun ? t('sandbox.dryRunButton') : t('sandbox.invokeButton'))}
+        </GradientButton>
+      </Stack>
 
       {sandboxMutation.isError && (
         <Alert severity="error">{t('sandbox.invokeError', { error: extractApiError(sandboxMutation.error) })}</Alert>
       )}
+
+      {sandboxResponse?.debug && <CdsDebugPanel debug={sandboxResponse.debug} />}
 
       {/* Critical Card Dialog */}
       {currentCritical && (

--- a/frontend/src/locales/en/cds.json
+++ b/frontend/src/locales/en/cds.json
@@ -9,7 +9,23 @@
     "tabManage": "Manage Services",
     "tabAnalytics": "Analytics",
     "tabSandbox": "Sandbox",
-    "tabApiKeys": "API Keys"
+    "tabApiKeys": "API Keys",
+    "tabRecent": "Recent (Admin)"
+  },
+  "recentInvocations": {
+    "total": "Recent invocations: {{count}}",
+    "refresh": "Refresh",
+    "time": "Time",
+    "service": "Service",
+    "hook": "Hook",
+    "patient": "Patient",
+    "status": "Status",
+    "duration": "Duration",
+    "detail": "Detail",
+    "success": "Success",
+    "failed": "Failed",
+    "empty": "No invocations recorded yet",
+    "loadError": "Failed to load recent invocations"
   },
   "invoke": {
     "serviceLabel": "CDS Service",
@@ -62,7 +78,7 @@
     "serviceIdHelperText": "Unique identifier for the service (cannot be changed after creation)",
     "titleLabel": "Title",
     "hookTypeLabel": "Hook Type",
-    "contextFieldsHint": "This hook type requires the following context fields: {{fields}}",
+    "contextFieldsHint": "⚙️ Callers (EHR / Sandbox / Invoke panel) must provide the following context fields: {{fields}}",
     "descriptionLabel": "Description",
     "defaultIndicatorLabel": "Default Indicator",
     "loadFromLibrary": "Load from Library",
@@ -110,6 +126,9 @@
     "invokeButton": "Invoke in Sandbox",
     "invokeFailed": "Sandbox invocation failed: {{error}}",
     "invokeError": "Sandbox invocation failed: {{error}}",
+    "debugMode": "Debug Mode",
+    "dryRun": "Dry Run",
+    "dryRunButton": "Run Dry",
     "results": "Sandbox Results ({{count}} cards)",
     "suggestions": "Suggestions:",
     "systemActions": "System Actions",
@@ -135,6 +154,45 @@
       "deleteFailed": "Failed to delete preset: {{error}}",
       "loadedChip": "Preset: {{name}}",
       "overwrite": "Overwrite"
+    }
+  },
+  "debug": {
+    "title": "Debug Info",
+    "stackTrace": "Stack trace (top frames)",
+    "invocationContext": "Invocation context",
+    "contextWarnings": "Context Warnings",
+    "prefetchStatus": "Prefetch Status",
+    "prefetchKey": "Key",
+    "prefetchCount": "Count",
+    "prefetchTime": "Time",
+    "prefetchDetail": "Detail",
+    "compiledElm": "Compiled ELM (JSON)",
+    "dryRunTitle": "Dry Run",
+    "dryRunDescription": "CQL execution was skipped. Only prefetch resolution, context binding, and FHIR server diagnostics were performed.",
+    "resourcesByType": "Available Resources (by type)",
+    "phase": {
+      "prefetch_resolution": "Prefetch Resolution",
+      "prefetch_provider_build": "Prefetch Provider",
+      "cql_translation": "CQL Translation",
+      "cql_execution": "CQL Execution",
+      "card_generation": "Card Generation",
+      "unknown": "Unknown"
+    },
+    "fhirStatus": {
+      "not_attempted": "Not Attempted",
+      "attempted": "Attempted",
+      "success": "Success",
+      "error": "Error"
+    },
+    "fhirCategory": {
+      "timeout": "Timeout",
+      "network": "Network",
+      "not_found": "Not Found",
+      "unauthorized": "Unauthorized",
+      "forbidden": "Forbidden",
+      "server_error": "Server Error",
+      "unsupported_version": "Unsupported FHIR version",
+      "other": "Other"
     }
   },
   "critical": {

--- a/frontend/src/locales/zh-TW/cds.json
+++ b/frontend/src/locales/zh-TW/cds.json
@@ -9,7 +9,23 @@
     "tabManage": "管理服務",
     "tabAnalytics": "分析",
     "tabSandbox": "沙盒",
-    "tabApiKeys": "API 金鑰"
+    "tabApiKeys": "API 金鑰",
+    "tabRecent": "最近調用（管理員）"
+  },
+  "recentInvocations": {
+    "total": "最近調用紀錄：{{count}} 筆",
+    "refresh": "重新整理",
+    "time": "時間",
+    "service": "服務",
+    "hook": "Hook",
+    "patient": "病患",
+    "status": "狀態",
+    "duration": "耗時",
+    "detail": "詳情",
+    "success": "成功",
+    "failed": "失敗",
+    "empty": "尚無調用紀錄",
+    "loadError": "無法載入最近調用紀錄"
   },
   "invoke": {
     "serviceLabel": "CDS 服務",
@@ -62,7 +78,7 @@
     "serviceIdHelperText": "服務的唯一識別碼（建立後無法變更）",
     "titleLabel": "標題",
     "hookTypeLabel": "Hook 類型",
-    "contextFieldsHint": "此 Hook 類型需要以下上下文欄位：{{fields}}",
+    "contextFieldsHint": "⚙️ 呼叫方（EHR / Sandbox / Invoke 面板）須提供以下上下文欄位：{{fields}}",
     "descriptionLabel": "說明",
     "defaultIndicatorLabel": "預設指示器",
     "loadFromLibrary": "從函式庫載入",
@@ -110,6 +126,9 @@
     "invokeButton": "在沙盒中調用",
     "invokeFailed": "沙盒調用失敗：{{error}}",
     "invokeError": "沙盒調用失敗：{{error}}",
+    "debugMode": "除錯模式",
+    "dryRun": "乾跑模式",
+    "dryRunButton": "執行乾跑",
     "results": "沙盒結果（{{count}} 張卡片）",
     "suggestions": "建議：",
     "systemActions": "系統動作",
@@ -135,6 +154,45 @@
       "deleteFailed": "刪除預設失敗：{{error}}",
       "loadedChip": "預設：{{name}}",
       "overwrite": "覆蓋更新"
+    }
+  },
+  "debug": {
+    "title": "除錯資訊",
+    "stackTrace": "堆疊追蹤（前幾個）",
+    "invocationContext": "呼叫上下文",
+    "contextWarnings": "上下文警告",
+    "prefetchStatus": "Prefetch 狀態",
+    "prefetchKey": "鍵",
+    "prefetchCount": "數量",
+    "prefetchTime": "耗時",
+    "prefetchDetail": "詳情",
+    "compiledElm": "編譯後 ELM (JSON)",
+    "dryRunTitle": "乾跑模式",
+    "dryRunDescription": "已跳過 CQL 執行。只進行 prefetch 解析、上下文綁定、FHIR server 診斷。",
+    "resourcesByType": "可用資源（依類型）",
+    "phase": {
+      "prefetch_resolution": "Prefetch 解析",
+      "prefetch_provider_build": "Prefetch 資料建立",
+      "cql_translation": "CQL 翻譯",
+      "cql_execution": "CQL 執行",
+      "card_generation": "卡片生成",
+      "unknown": "未知"
+    },
+    "fhirStatus": {
+      "not_attempted": "未嘗試",
+      "attempted": "嘗試中",
+      "success": "成功",
+      "error": "錯誤"
+    },
+    "fhirCategory": {
+      "timeout": "逾時",
+      "network": "網路",
+      "not_found": "找不到資源",
+      "unauthorized": "未授權",
+      "forbidden": "禁止存取",
+      "server_error": "伺服器錯誤",
+      "unsupported_version": "不支援的 FHIR 版本",
+      "other": "其他"
     }
   },
   "critical": {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -291,11 +291,50 @@ export interface CdsRequest {
     encounterId?: string
   }
   prefetch?: Record<string, unknown>
+  debugMode?: boolean
+  dryRun?: boolean
 }
 
 export interface CdsResponse {
   cards: CdsCard[]
   systemActions?: SystemAction[]
+  debug?: CdsDebugInfo
+}
+
+export interface CdsDebugInfo {
+  debugTrace?: DebugTrace
+  error?: CdsErrorInfo
+  invocationContext?: Record<string, unknown>
+  prefetchStatus?: PrefetchStatus[]
+  contextWarnings?: string[]
+  fhirServerDiagnostics?: FhirServerDiagnostics
+  dryRun?: boolean
+  resourcesByType?: Record<string, number>
+}
+
+export interface CdsErrorInfo {
+  phase: string
+  errorType: string
+  message: string
+  stackTraceSummary?: string[]
+}
+
+export interface PrefetchStatus {
+  key: string
+  status: 'success' | 'failed' | 'empty'
+  count?: number
+  elapsedMs?: number
+  error?: string
+  resolvedUrl?: string
+}
+
+export interface FhirServerDiagnostics {
+  url: string
+  status: 'not_attempted' | 'attempted' | 'success' | 'error'
+  errorCategory?: string
+  errorMessage?: string
+  httpStatus?: number
+  elapsedMs?: number
 }
 
 export interface CdsCard {
@@ -369,6 +408,8 @@ export interface CdsSandboxRequest {
   testData?: Record<string, unknown>
   draftOrders?: unknown
   appointments?: unknown
+  debugMode?: boolean
+  dryRun?: boolean
 }
 
 export interface SandboxPresetRequest {
@@ -792,6 +833,8 @@ export interface DebugTrace {
   retrieveTraces: RetrieveTrace[]
   totalTimeMs: number
   sourceLocators?: Record<string, string>
+  /** Compiled ELM JSON (only populated when debugMode=true). */
+  elmJson?: string
 }
 
 export interface ExpressionTrace {


### PR DESCRIPTION
## Summary
- **8 合 1 除錯套件** 解決「CQL 在 Editor 測沒問題但 CDS 呼叫失敗」的除錯盲區
- 後端：`CdsInvocationException` (Phase enum) + `CdsResponse.debug` 結構化回應 + `CdsRecentInvocationsService` ring buffer
- 前端：`CdsDebugPanel` 統一顯示所有診斷 + `RecentInvocationsPanel` admin 面板 + Sandbox Debug/Dry-Run switches

## 關聯 Issue
- 實作 #198（需求）

## 8 個 Feature

| # | Feature | 說明 |
|---|---------|------|
| 1 | **CDS Sandbox Debug Mode** | debugMode 傳入 CqlExecutionService，回傳 DebugTrace（expressions + retrieves），前端沿用 ExecutionPanel 的 DebugPanel |
| 2 | **結構化錯誤回應** | `CdsInvocationException` 帶 Phase；response 含 errorType + stack top-5 + invocation context |
| 3 | **Prefetch Resolution 報告** | PrefetchResolver.resolveWithStatus() per-key 狀態；sandbox testData 也追蹤 |
| 4 | **Context Diagnostics** | patientId 缺失 / Patient 不在 prefetch 的警告 |
| 5 | **FHIR Server 診斷** | URL + 錯誤分類（timeout/network/not_found/unauthorized/forbidden/server_error/unsupported_version/other）+ HTTP code |
| 6 | **ELM Viewer** | translator.toJson() 帶入 debugTrace.elmJson；前端可折疊 code block |
| 7 | **Admin Recent Invocations** | ring buffer (100)，`/api/admin/cds/recent-invocations`；新 tab（ADMIN/DEPARTMENT_ADMIN 可見），10s 自動 refetch |
| 8 | **Dry Run Mode** | 跳過 CQL 執行，回傳 prefetch + context + resourcesByType 清單 |

## 變更說明

### 後端（新增 2 + 修改 11）
| 檔案 | 變更 |
|------|------|
| `CdsInvocationException.java` | **新增** — Phase enum |
| `CdsRecentInvocationsService.java` | **新增** — in-memory ring buffer |
| `CdsResponse.java` | 加 `debug` 欄位 + CdsDebugInfo/CdsErrorInfo/PrefetchStatus/FhirServerDiagnostics inner classes |
| `CdsRequest.java` / `CdsSandboxRequest.java` | 加 `debugMode` + `dryRun` |
| `CdsInvocationService.java` | phase-wrapped try/catch + InvocationDiagnostics 累積器 + dry-run short-circuit |
| `CdsHooksController.java` | sandbox 傳遞 debugMode/dryRun |
| `PrefetchResolver.java` | 新增 `resolveWithStatus()` 回傳 `ResolutionResult` |
| `PrefetchRetrieveProvider.java` | 新增 `hasPatient()` + `getResourceCountsByType()` |
| `CqlExecutionService.java` | DebugTrace 填入 elmJson |
| `CqlExecutionResponse.java` | DebugTrace 加 elmJson |
| `AdminController.java` | `/api/admin/cds/recent-invocations` 端點 |
| `CdsInvocationServiceTest.java` | 加 3 個 debug 測試 |

### 前端（新增 2 + 修改 5）
| 檔案 | 變更 |
|------|------|
| `CdsDebugPanel.tsx` | **新增** — 錯誤 Alert + FHIR 診斷 + Prefetch table + Context 警告 + invocation context + ELM viewer + dry-run section |
| `RecentInvocationsPanel.tsx` | **新增** — admin 最近調用表格 |
| `CdsPanel.tsx` | 加 "Recent (Admin)" tab（依 role 條件顯示） |
| `SandboxPanel.tsx` | 加 Debug Mode + Dry Run switches |
| `InvokeServicePanel.tsx` | 加 Debug Mode switch |
| `types/index.ts` | CdsDebugInfo/PrefetchStatus/FhirServerDiagnostics/DebugTrace.elmJson |
| `locales/{en,zh-TW}/cds.json` | 全套 debug/recentInvocations i18n |

## 測試紀錄
- [x] Backend `mvn compile`: BUILD SUCCESS
- [x] `HookContextRequirementsTest` + `HookTypeValidatorTest`: 28/28 通過
- [x] Frontend `npx tsc --noEmit`: EXIT_CODE 0
- [x] ESLint clean

## 風險評估
- **相容性**: `debug` 欄位 `@JsonInclude(NON_NULL)`，老 EHR 客戶端不受影響；`debugMode`/`dryRun` 預設 `false`
- **效能**: Debug mode 只在明確開啟時才收集 trace；ring buffer 綁定 100 筆，記憶體開銷極小
- **權限**: `/api/admin/cds/recent-invocations` 受 `/api/admin/**` 的 ADMIN role 保護，前端 tab 依 role 顯示

## IEC 62304 / ISO 14971 追溯
| 項目 | 內容 |
|------|------|
| 安全性等級 | A（除錯/診斷功能，無臨床決策影響） |
| 需求追溯 | #198 |
| 驗證方式 | 單元測試 + 型別檢查 + 手動 sandbox 測試 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)