### PR TITLE
fix: bulk fetch follows cross-library ExpressionRef for retrieve discovery (#BUG-111)

### DIFF
--- a/backend/src/main/java/com/cqlplatform/service/cql/CqlExecutionService.java
+++ b/backend/src/main/java/com/cqlplatform/service/cql/CqlExecutionService.java
@@ -622,18 +622,40 @@ public class CqlExecutionService {
 
     /**
      * Extract FHIR retrieve types directly from a pre-translated ELM Library object.
+     * Same-library ExpressionRefs are covered by the outer loop over {@code statements.def};
+     * cross-library ExpressionRefs require resolving the included library via {@code libraryManager}
+     * so we can walk its own ExpressionDefs (otherwise bulk-fetch misses resource types that are
+     * only retrieved inside included libraries — e.g. a main measure that delegates its Initial
+     * Population to an external library containing the actual [Encounter]/[Condition] retrieves).
      */
     public Set<String> extractRetrieveTypesFromLibrary(org.hl7.elm.r1.Library library) {
+        return extractRetrieveTypesFromLibrary(library, null);
+    }
+
+    /**
+     * Variant that follows cross-library ExpressionRefs through the given LibraryManager.
+     * Passing {@code null} reverts to the legacy behavior (skips cross-lib refs).
+     */
+    public Set<String> extractRetrieveTypesFromLibrary(org.hl7.elm.r1.Library library, LibraryManager libraryManager) {
         Set<String> types = new HashSet<>();
+        Set<String> visited = new HashSet<>();
         if (library.getStatements() != null && library.getStatements().getDef() != null) {
             for (org.hl7.elm.r1.ExpressionDef def : library.getStatements().getDef()) {
-                collectRetrieveTypes(def.getExpression(), types);
+                collectRetrieveTypes(def.getExpression(), types, library, libraryManager, visited);
             }
         }
         return types;
     }
 
     private void collectRetrieveTypes(org.hl7.elm.r1.Element element, Set<String> types) {
+        collectRetrieveTypes(element, types, null, null, new HashSet<>());
+    }
+
+    private void collectRetrieveTypes(org.hl7.elm.r1.Element element,
+                                      Set<String> types,
+                                      org.hl7.elm.r1.Library currentLibrary,
+                                      LibraryManager libraryManager,
+                                      Set<String> visitedCrossLibRefs) {
         if (element == null) return;
         if (element instanceof org.hl7.elm.r1.Retrieve retrieve) {
             javax.xml.namespace.QName dt = retrieve.getDataType();
@@ -644,23 +666,81 @@ public class CqlExecutionService {
         // Recurse into child expressions using reflection-free approach
         if (element instanceof org.hl7.elm.r1.Query query) {
             if (query.getSource() != null) {
-                for (var src : query.getSource()) collectRetrieveTypes(src.getExpression(), types);
+                for (var src : query.getSource()) collectRetrieveTypes(src.getExpression(), types, currentLibrary, libraryManager, visitedCrossLibRefs);
             }
-            if (query.getWhere() != null) collectRetrieveTypes(query.getWhere(), types);
+            if (query.getWhere() != null) collectRetrieveTypes(query.getWhere(), types, currentLibrary, libraryManager, visitedCrossLibRefs);
         } else if (element instanceof org.hl7.elm.r1.FunctionRef funcRef) {
             // FunctionRef extends ExpressionRef but carries operands from THIS library
             // (e.g. C3F.Verified([Observation: ...]) — the [Observation] Retrieve is our operand)
             if (funcRef.getOperand() != null) {
-                for (var op : funcRef.getOperand()) collectRetrieveTypes(op, types);
+                for (var op : funcRef.getOperand()) collectRetrieveTypes(op, types, currentLibrary, libraryManager, visitedCrossLibRefs);
             }
-        } else if (element instanceof org.hl7.elm.r1.ExpressionRef) {
-            // Skip — will be resolved by the defining expression
+            // Cross-library function calls also need to walk into the included library body
+            // in case the function references retrieves internally (e.g. C3F.ObservationLookBack
+            // which wraps [Observation]). Only follow when we have libraryManager context.
+            if (funcRef.getLibraryName() != null && libraryManager != null && currentLibrary != null) {
+                followCrossLibraryRef(funcRef.getLibraryName(), funcRef.getName(),
+                        types, currentLibrary, libraryManager, visitedCrossLibRefs);
+            }
+        } else if (element instanceof org.hl7.elm.r1.ExpressionRef ref) {
+            // Same-library refs are covered by the outer loop; cross-library refs must be followed
+            if (ref.getLibraryName() != null && libraryManager != null && currentLibrary != null) {
+                followCrossLibraryRef(ref.getLibraryName(), ref.getName(),
+                        types, currentLibrary, libraryManager, visitedCrossLibRefs);
+            }
         } else if (element instanceof org.hl7.elm.r1.UnaryExpression ue) {
-            collectRetrieveTypes(ue.getOperand(), types);
+            collectRetrieveTypes(ue.getOperand(), types, currentLibrary, libraryManager, visitedCrossLibRefs);
         } else if (element instanceof org.hl7.elm.r1.BinaryExpression be) {
-            for (var op : be.getOperand()) collectRetrieveTypes(op, types);
+            for (var op : be.getOperand()) collectRetrieveTypes(op, types, currentLibrary, libraryManager, visitedCrossLibRefs);
         } else if (element instanceof org.hl7.elm.r1.NaryExpression ne) {
-            for (var op : ne.getOperand()) collectRetrieveTypes(op, types);
+            for (var op : ne.getOperand()) collectRetrieveTypes(op, types, currentLibrary, libraryManager, visitedCrossLibRefs);
+        }
+    }
+
+    /**
+     * Resolve {@code alias.defName} via the current library's IncludeDefs, then walk the referenced
+     * define in the included library. Guards against recursion cycles via {@code visited}.
+     */
+    private void followCrossLibraryRef(String libraryAlias,
+                                       String defName,
+                                       Set<String> types,
+                                       org.hl7.elm.r1.Library currentLibrary,
+                                       LibraryManager libraryManager,
+                                       Set<String> visited) {
+        if (libraryAlias == null || defName == null) return;
+        // Find the include def that maps this alias to a library path/version
+        if (currentLibrary.getIncludes() == null || currentLibrary.getIncludes().getDef() == null) return;
+        org.hl7.elm.r1.IncludeDef includeDef = null;
+        for (var inc : currentLibrary.getIncludes().getDef()) {
+            if (libraryAlias.equals(inc.getLocalIdentifier())) { includeDef = inc; break; }
+        }
+        if (includeDef == null) return;
+
+        String includedPath = includeDef.getPath();
+        String includedVersion = includeDef.getVersion();
+        String visitKey = includedPath + "|" + includedVersion + "|" + defName;
+        if (visited.contains(visitKey)) return;
+        visited.add(visitKey);
+
+        // Locate the compiled library in the libraryManager cache
+        org.hl7.elm.r1.Library includedLibrary = null;
+        for (var entry : libraryManager.getCompiledLibraries().entrySet()) {
+            org.hl7.elm.r1.VersionedIdentifier vid = entry.getKey();
+            if (vid == null || vid.getId() == null) continue;
+            if (vid.getId().equals(includedPath)
+                    && (includedVersion == null || includedVersion.equals(vid.getVersion()))) {
+                includedLibrary = entry.getValue().getLibrary();
+                break;
+            }
+        }
+        if (includedLibrary == null || includedLibrary.getStatements() == null) return;
+
+        // Find the ExpressionDef by name and recurse
+        for (org.hl7.elm.r1.ExpressionDef def : includedLibrary.getStatements().getDef()) {
+            if (defName.equals(def.getName())) {
+                collectRetrieveTypes(def.getExpression(), types, includedLibrary, libraryManager, visited);
+                break;
+            }
         }
     }
 
@@ -705,7 +785,7 @@ public class CqlExecutionService {
                 retrieveProvider = prefetchProvider;
             } else if (request.getPatientId() != null) {
                 // Extract retrieve types directly from pre-translated ELM Library object
-                Set<String> retrieveTypes = extractRetrieveTypesFromLibrary(ctx.elmLibrary());
+                Set<String> retrieveTypes = extractRetrieveTypesFromLibrary(ctx.elmLibrary(), ctx.libraryManager());
                 retrieveTypes.add("Patient");
                 String pid = request.getPatientId();
                 if (pid.startsWith("Patient/")) pid = pid.substring("Patient/".length());

--- a/backend/src/main/java/com/cqlplatform/service/measure/MeasureEvaluationService.java
+++ b/backend/src/main/java/com/cqlplatform/service/measure/MeasureEvaluationService.java
@@ -128,7 +128,7 @@ public class MeasureEvaluationService {
                 long bulkStart = System.currentTimeMillis();
                 try {
                     Set<String> retrieveTypes = cqlExecutionService.extractRetrieveTypesFromLibrary(
-                            preTranslated.elmLibrary());
+                            preTranslated.elmLibrary(), preTranslated.libraryManager());
                     retrieveTypes.add("Patient");
                     bulkData = fhirDataProviderService.bulkFetchAllPatients(
                             context.getFhirServerUrl(), patients, retrieveTypes);

--- a/backend/src/test/java/com/cqlplatform/service/cql/CqlExecutionIntegrationTest.java
+++ b/backend/src/test/java/com/cqlplatform/service/cql/CqlExecutionIntegrationTest.java
@@ -490,6 +490,62 @@ class CqlExecutionIntegrationTest {
     }
 
     // ═══════════════════════════════════════════════════════════════════════
+    // 10. Cross-library retrieve discovery (BUG-111)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("10. Cross-library retrieve discovery (BUG-111)")
+    class CrossLibraryRetrieveDiscovery {
+
+        @Test
+        @DisplayName("extractRetrieveTypesFromLibrary follows cross-library ExpressionRef into included library")
+        void crossLibraryRef_shouldDiscoverRetrievesInIncludedLib() {
+            // Arrange: included library that declares [Encounter] and [Condition] retrieves
+            String includedCql = "library ExternalLib version '1.0.0'\n"
+                    + "using FHIR version '4.0.1'\n"
+                    + "include FHIRHelpers version '4.0.1' called FHIRHelpers\n"
+                    + "context Patient\n"
+                    + "define \"Qualifying Encounters\": [Encounter] E where E.status = 'finished'\n"
+                    + "define \"Active Conditions\": [Condition] C where C.clinicalStatus is not null\n";
+
+            com.cqlplatform.entity.CqlLibraryEntity includedEntity = new com.cqlplatform.entity.CqlLibraryEntity();
+            includedEntity.setName("ExternalLib");
+            includedEntity.setVersion("1.0.0");
+            includedEntity.setCqlContent(includedCql);
+            lenient().when(libraryRepository.findByNameAndVersion("ExternalLib", "1.0.0"))
+                    .thenReturn(Optional.of(includedEntity));
+            lenient().when(libraryRepository.findByName("ExternalLib"))
+                    .thenReturn(List.of(includedEntity));
+
+            // Main library delegates its Initial Population to the included library via libref
+            String mainCql = "library MainLib version '1.0.0'\n"
+                    + "using FHIR version '4.0.1'\n"
+                    + "include FHIRHelpers version '4.0.1' called FHIRHelpers\n"
+                    + "include ExternalLib version '1.0.0' called EL\n"
+                    + "context Patient\n"
+                    + "define \"Initial Population\": exists(EL.\"Qualifying Encounters\")\n"
+                    + "define \"Measure Population\": [Observation]\n";
+
+            // Act
+            CqlExecutionService.PreTranslatedContext ctx = executionService.translateOnce(mainCql);
+
+            // Legacy (no libraryManager): misses Encounter/Condition from included lib
+            Set<String> typesWithoutLibMgr = executionService.extractRetrieveTypesFromLibrary(ctx.elmLibrary());
+            assertThat(typesWithoutLibMgr).contains("Observation");
+            // Assert that the pre-fix behavior demonstrably omits Encounter
+            // (this is the bug signature — patients would see 0 Encounters during bulk fetch)
+            assertThat(typesWithoutLibMgr).doesNotContain("Encounter");
+
+            // New behavior (with libraryManager): follows the cross-library ExpressionRef
+            Set<String> typesWithLibMgr = executionService.extractRetrieveTypesFromLibrary(
+                    ctx.elmLibrary(), ctx.libraryManager());
+            assertThat(typesWithLibMgr)
+                    .contains("Observation")
+                    .contains("Encounter");  // now discovered via EL."Qualifying Encounters"
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
     // Helpers
     // ═══════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary

Fixes a silent bug where eCQM bulk-prefetch missed resource types retrieved **inside included libraries**. When a measure's population criteria delegates to a libref (e.g. \`define "Initial Population": "DFLR"."Initial Population"\`, and DFLR internally retrieves \`[Encounter]\`), bulk fetch scanned only the main library's retrieves and never discovered that Encounter needed to be pulled. Every patient received 0 Encounters → DFLR's population silently evaluated to empty → score came back null with no error.

Hit in the field immediately after PAT-067 (user switched a1c_dm's IP to \`DFLR."Initial Population"\` — IP=0 for every period).

關聯 Issue: #212 (original eCQM requirement), #220 (risk analysis)

## Root cause

\`CqlExecutionService.collectRetrieveTypes\` skipped \`ExpressionRef\` unconditionally with a comment claiming "will be resolved by the defining expression" — which is only true for same-library refs (the outer loop over \`statements.def\` already walks those). For cross-library refs (\`libraryName != null\`), the target define lives in the included library, and we never followed into it.

## Fix

- \`collectRetrieveTypes\` now takes \`(currentLibrary, libraryManager, visited)\` context. When it hits an \`ExpressionRef\` or \`FunctionRef\` whose \`libraryName\` is non-null:
  1. Look up the matching \`IncludeDef\` in \`currentLibrary.getIncludes().getDef()\` to map the alias → path/version
  2. Resolve the compiled library via \`libraryManager.getCompiledLibraries()\`
  3. Find the target \`ExpressionDef\` by name and recurse
- Cycle guard: \`visited\` keyed by \`path|version|defName\`
- \`extractRetrieveTypesFromLibrary\` gains a \`(library, libraryManager)\` overload; the single-arg version keeps the legacy no-follow behavior for any residual callers
- Two call sites updated: \`CqlExecutionService.executeWithPreTranslated\` (line 788) and \`MeasureEvaluationService\` bulk-fetch path (line 130) pass \`preTranslated.libraryManager()\`
- Integration test \`CrossLibraryRetrieveDiscovery.crossLibraryRef_shouldDiscoverRetrievesInIncludedLib\` locks the invariant: without libMgr the result omits Encounter; with libMgr it's present

## Test plan

- [x] New integration test — passes in CI environment (local JDK 25 has pre-existing Mockito-inline mocking limitation unrelated to this PR)
- [ ] VM smoke: re-run a1c_dm with DFLR-based Initial Population after deploy — Encounter count in bulk fetch > 0, DFLR IP matches patients with diabetes AMB encounters in period
- [ ] CI: full backend test suite, Security Scan

## Risk assessment

- **Scope**: only bulk-prefetch retrieve-type discovery changes. Does not affect actual CQL execution, engine dispatch, or scoring logic
- **Backward compat**: single-arg \`extractRetrieveTypesFromLibrary(library)\` overload preserved for any residual callers — legacy behavior unchanged
- **Edge case**: circular include graphs prevented by visited-set; fall-back to original walk if libraryManager is null
- Full risk rationale in #220

## IEC 62304 / ISO 14971 追溯

| Ticket | Requirement | Design | Risk | Verification |
|--------|-------------|--------|------|--------------|
| BUG-111 | #212 | — | #220 | CqlExecutionIntegrationTest.CrossLibraryRetrieveDiscovery |

🤖 Generated with [Claude Code](https://claude.com/claude-code)