### PR TITLE
fix: DatabaseLibrarySourceProvider — structural guard against silent stale-CQL execution (#PAT-073 / BUG-113)

### DIFF
--- a/backend/src/main/java/com/cqlplatform/service/cql/CqlExecutionService.java
+++ b/backend/src/main/java/com/cqlplatform/service/cql/CqlExecutionService.java
@@ -109,7 +109,11 @@ public class CqlExecutionService {
      * Call this once before a batch of patient evaluations.
      */
     public PreTranslatedContext translateOnce(String cql) {
-        LibraryManager libraryManager = LibraryManagerFactory.create(libraryRepository);
+        // createContext gives us a handle to the DB provider so we can suppress it
+        // for the library we're about to translate — the fresh source is the truth,
+        // not whatever happens to sit in cql_library with the same name+version.
+        LibraryManagerFactory.LibraryContext libCtx = LibraryManagerFactory.createContext(libraryRepository);
+        LibraryManager libraryManager = libCtx.libraryManager;
         CqlTranslator translator = CqlTranslator.fromText(cql, libraryManager);
         org.hl7.elm.r1.Library elmLibrary = translator.toELM();
 
@@ -134,6 +138,14 @@ public class CqlExecutionService {
                     new InMemoryLibrarySourceProvider(libraryId.getId(), libraryId.getVersion(), cql));
             if (translator.getTranslatedLibrary() != null) {
                 seedCompiledLibrary(libraryManager, libraryId, translator.getTranslatedLibrary());
+            }
+            // Defense-in-depth (BUG-107 regression lock): even if the compiled-library
+            // cache is cleared or bypassed by a future engine-level lookup, the DB
+            // provider will refuse to hand back its stored copy of THIS library id.
+            // Other libraries the CQL includes (e.g. DFLR, FHIRHelpers) remain
+            // resolvable from DB normally.
+            if (libCtx.databaseProvider != null) {
+                libCtx.databaseProvider.excludeIdentifier(libraryId);
             }
         }
 

--- a/backend/src/main/java/com/cqlplatform/service/cql/DatabaseLibrarySourceProvider.java
+++ b/backend/src/main/java/com/cqlplatform/service/cql/DatabaseLibrarySourceProvider.java
@@ -5,6 +5,7 @@ import com.cqlplatform.repository.CqlLibraryRepository;
 import kotlinx.io.CoreKt;
 import kotlinx.io.JvmCoreKt;
 import kotlinx.io.Source;
+import lombok.extern.slf4j.Slf4j;
 import org.cqframework.cql.cql2elm.LibrarySourceProvider;
 import org.hl7.elm.r1.VersionedIdentifier;
 
@@ -12,20 +13,83 @@ import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * Resolves CQL library source from the {@code cql_library} table.
+ *
+ * <h2>Defensive design (BUG-107 family)</h2>
+ *
+ * <p>The {@link DefaultLibrarySourceLoader} in cql-to-elm queries providers in
+ * registration order and returns the first non-null source. When this provider is
+ * registered alongside an {@code InMemoryLibrarySourceProvider} for a freshly-edited
+ * library, the DB copy would silently win if its version number matches — returning
+ * the stale stored CQL and running it instead of the editor text (BUG-107).
+ *
+ * <p>Two safeguards live in this class:
+ * <ol>
+ *   <li><b>Exclusion list.</b> Callers can register library identifiers that must
+ *       NEVER be resolved from DB — typically the identifier of the CQL currently
+ *       being translated. If the engine asks for an excluded identifier we return
+ *       {@code null} and log a warning, forcing fallback to another provider
+ *       (usually the in-memory provider holding the user's fresh text).</li>
+ *   <li><b>Explicit logging.</b> Every successful DB lookup is logged at INFO level
+ *       with the library id/version, so unexpected DB fallbacks are visible in
+ *       operator telemetry instead of completing silently.</li>
+ * </ol>
+ */
+@Slf4j
 public class DatabaseLibrarySourceProvider implements LibrarySourceProvider {
 
     private final CqlLibraryRepository libraryRepository;
 
+    /**
+     * Identifiers whose DB resolution is suppressed. The InMemory provider (or any
+     * fresher source) is expected to handle these. Keyed by id+version string pair to
+     * tolerate the underlying VersionedIdentifier record's equality semantics.
+     */
+    private final ConcurrentHashMap<String, Boolean> excluded = new ConcurrentHashMap<>();
+
     public DatabaseLibrarySourceProvider(CqlLibraryRepository libraryRepository) {
         this.libraryRepository = libraryRepository;
+    }
+
+    /**
+     * Prevent DB resolution for the given identifier. Idempotent.
+     *
+     * <p>Used by {@code CqlExecutionService.translateOnce} to protect the
+     * freshly-translated library from being overwritten by its own stored copy on
+     * subsequent resolution passes.
+     */
+    public void excludeIdentifier(VersionedIdentifier identifier) {
+        if (identifier == null || identifier.getId() == null) return;
+        excluded.put(key(identifier.getId(), identifier.getVersion()), Boolean.TRUE);
+    }
+
+    /** Remove a previously-set exclusion. Rarely needed — mainly for test isolation. */
+    public void clearExclusion(VersionedIdentifier identifier) {
+        if (identifier == null) return;
+        excluded.remove(key(identifier.getId(), identifier.getVersion()));
+    }
+
+    /** Clear all exclusions. Used in tests. */
+    public void clearExclusions() {
+        excluded.clear();
     }
 
     @Override
     public Source getLibrarySource(VersionedIdentifier libraryIdentifier) {
         String name = libraryIdentifier.getId();
         String version = libraryIdentifier.getVersion();
+
+        if (isExcluded(name, version)) {
+            log.warn("DB fallback suppressed for excluded library identifier {}|{} "
+                            + "(fresh source should be provided by in-memory provider)",
+                    name, version);
+            return null;
+        }
 
         Optional<CqlLibraryEntity> entity;
         if (version != null && !version.isBlank()) {
@@ -37,12 +101,30 @@ public class DatabaseLibrarySourceProvider implements LibrarySourceProvider {
                     .max(Comparator.comparing(CqlLibraryEntity::getVersion, new SemanticVersionComparator()));
         }
 
-        return entity
-                .map(e -> {
-                    ByteArrayInputStream bais = new ByteArrayInputStream(
-                            e.getCqlContent().getBytes(StandardCharsets.UTF_8));
-                    return (Source) CoreKt.buffered(JvmCoreKt.asSource(bais));
-                })
-                .orElse(null);
+        if (entity.isEmpty()) {
+            return null;
+        }
+
+        CqlLibraryEntity e = entity.get();
+        log.info("Resolved library {}|{} from DB (requested {}|{})",
+                e.getName(), e.getVersion(), name, version);
+        ByteArrayInputStream bais = new ByteArrayInputStream(
+                e.getCqlContent().getBytes(StandardCharsets.UTF_8));
+        return CoreKt.buffered(JvmCoreKt.asSource(bais));
+    }
+
+    private boolean isExcluded(String name, String version) {
+        if (excluded.containsKey(key(name, version))) return true;
+        // Also treat "no version specified" as excluded if ANY version of this name
+        // is in the exclusion set — protects against ambiguous-version lookups falling
+        // through to a DB latest-version resolution while a fresh translation is live.
+        if (version == null) {
+            return excluded.keySet().stream().anyMatch(k -> k.startsWith(name + "|"));
+        }
+        return false;
+    }
+
+    private static String key(String name, String version) {
+        return Objects.toString(name, "") + "|" + Objects.toString(version, "");
     }
 }

--- a/backend/src/main/java/com/cqlplatform/service/cql/LibraryManagerFactory.java
+++ b/backend/src/main/java/com/cqlplatform/service/cql/LibraryManagerFactory.java
@@ -35,16 +35,32 @@ public class LibraryManagerFactory {
     }
 
     /**
-     * Creates a LibraryManager with default compiler options.
+     * Holder for a configured {@link LibraryManager} plus handles to its registered
+     * providers so callers can adjust behavior after creation.
+     *
+     * <p>Most importantly, {@link #databaseProvider} is exposed so callers can exclude
+     * the just-translated library's identifier to prevent the stale-DB-wins bug
+     * (BUG-107 family). Null when no {@code CqlLibraryRepository} was supplied.
      */
-    public static LibraryManager create(CqlLibraryRepository libraryRepository) {
-        return create(libraryRepository, defaultOptions());
+    public static class LibraryContext {
+        public final LibraryManager libraryManager;
+        public final DatabaseLibrarySourceProvider databaseProvider; // nullable
+
+        LibraryContext(LibraryManager libraryManager, DatabaseLibrarySourceProvider databaseProvider) {
+            this.libraryManager = libraryManager;
+            this.databaseProvider = databaseProvider;
+        }
     }
 
     /**
-     * Creates a LibraryManager with the given compiler options.
+     * Preferred factory — returns both the LibraryManager and the provider handles so
+     * callers can apply per-translation safeguards.
      */
-    public static LibraryManager create(CqlLibraryRepository libraryRepository, CqlCompilerOptions options) {
+    public static LibraryContext createContext(CqlLibraryRepository libraryRepository) {
+        return createContext(libraryRepository, defaultOptions());
+    }
+
+    public static LibraryContext createContext(CqlLibraryRepository libraryRepository, CqlCompilerOptions options) {
         ModelManager mm = sharedModelManager;
         if (mm == null) {
             // Fallback: if called before Spring init (e.g. in tests), create inline
@@ -55,15 +71,36 @@ public class LibraryManagerFactory {
 
         LibraryManager libraryManager = new LibraryManager(mm, options);
 
+        DatabaseLibrarySourceProvider dbProvider = null;
         if (libraryRepository != null) {
-            libraryManager.getLibrarySourceLoader()
-                    .registerProvider(new DatabaseLibrarySourceProvider(libraryRepository));
+            dbProvider = new DatabaseLibrarySourceProvider(libraryRepository);
+            libraryManager.getLibrarySourceLoader().registerProvider(dbProvider);
         }
 
         libraryManager.getLibrarySourceLoader()
                 .registerProvider(new ClasspathLibrarySourceProvider("cql"));
 
-        return libraryManager;
+        return new LibraryContext(libraryManager, dbProvider);
+    }
+
+    /**
+     * Creates a LibraryManager with default compiler options.
+     *
+     * <p>Prefer {@link #createContext(CqlLibraryRepository)} for new code — the Context
+     * variant exposes the {@link DatabaseLibrarySourceProvider} handle needed to guard
+     * against stale-DB-wins bugs.
+     */
+    public static LibraryManager create(CqlLibraryRepository libraryRepository) {
+        return createContext(libraryRepository).libraryManager;
+    }
+
+    /**
+     * Creates a LibraryManager with the given compiler options.
+     *
+     * <p>Kept for backward compatibility. Prefer {@link #createContext}.
+     */
+    public static LibraryManager create(CqlLibraryRepository libraryRepository, CqlCompilerOptions options) {
+        return createContext(libraryRepository, options).libraryManager;
     }
 
     public static CqlCompilerOptions buildOptions(

--- a/backend/src/test/java/com/cqlplatform/service/cql/DatabaseLibrarySourceProviderTest.java
+++ b/backend/src/test/java/com/cqlplatform/service/cql/DatabaseLibrarySourceProviderTest.java
@@ -1,0 +1,136 @@
+package com.cqlplatform.service.cql;
+
+import com.cqlplatform.entity.CqlLibraryEntity;
+import com.cqlplatform.repository.CqlLibraryRepository;
+import kotlinx.io.Source;
+import org.hl7.elm.r1.VersionedIdentifier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@DisplayName("DatabaseLibrarySourceProvider — exclusion + silent-fallback guards")
+class DatabaseLibrarySourceProviderTest {
+
+    private CqlLibraryRepository repo;
+    private DatabaseLibrarySourceProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        repo = mock(CqlLibraryRepository.class);
+        provider = new DatabaseLibrarySourceProvider(repo);
+    }
+
+    // ── Helpers ──
+    private static VersionedIdentifier vid(String id, String version) {
+        return new VersionedIdentifier().withId(id).withVersion(version);
+    }
+
+    private static CqlLibraryEntity entity(String name, String version, String content) {
+        CqlLibraryEntity e = new CqlLibraryEntity();
+        e.setName(name);
+        e.setVersion(version);
+        e.setCqlContent(content);
+        return e;
+    }
+
+    @Test
+    @DisplayName("returns source for a known library when not excluded")
+    void returnsKnownLibrary() {
+        when(repo.findByNameAndVersion("MyLib", "1.0.0"))
+                .thenReturn(Optional.of(entity("MyLib", "1.0.0", "library MyLib version '1.0.0'\n")));
+
+        Source out = provider.getLibrarySource(vid("MyLib", "1.0.0"));
+
+        assertThat(out).isNotNull();
+    }
+
+    @Test
+    @DisplayName("returns null for excluded identifier — no DB call happens")
+    void excludedIdentifier_returnsNullAndDoesNotQueryRepo() {
+        provider.excludeIdentifier(vid("MyLib", "1.0.0"));
+
+        Source out = provider.getLibrarySource(vid("MyLib", "1.0.0"));
+
+        assertThat(out).isNull();
+        // Critical invariant: the repo is never asked; we don't even know what's in the DB
+        verifyNoInteractions(repo);
+    }
+
+    @Test
+    @DisplayName("exclusion is identity-specific — other libraries still resolve")
+    void exclusionIsPerIdentifier() {
+        provider.excludeIdentifier(vid("LibA", "1.0.0"));
+        when(repo.findByNameAndVersion("LibB", "1.0.0"))
+                .thenReturn(Optional.of(entity("LibB", "1.0.0", "library LibB version '1.0.0'\n")));
+
+        assertThat(provider.getLibrarySource(vid("LibA", "1.0.0"))).isNull();
+        assertThat(provider.getLibrarySource(vid("LibB", "1.0.0"))).isNotNull();
+    }
+
+    @Test
+    @DisplayName("exclusion is version-specific — other versions of the same name still resolve")
+    void exclusionIsPerVersion() {
+        provider.excludeIdentifier(vid("MyLib", "1.0.0"));
+        when(repo.findByNameAndVersion("MyLib", "2.0.0"))
+                .thenReturn(Optional.of(entity("MyLib", "2.0.0", "library MyLib version '2.0.0'\n")));
+
+        assertThat(provider.getLibrarySource(vid("MyLib", "1.0.0"))).isNull();
+        assertThat(provider.getLibrarySource(vid("MyLib", "2.0.0"))).isNotNull();
+    }
+
+    @Test
+    @DisplayName("version-less lookup for an excluded name is also suppressed (defensive)")
+    void versionLessLookupAgainstExcludedName() {
+        provider.excludeIdentifier(vid("MyLib", "1.0.0"));
+
+        // Even though we're asking for "any version of MyLib", we refuse — exclusion
+        // lives at the name level when no version is specified.
+        Source out = provider.getLibrarySource(vid("MyLib", null));
+        assertThat(out).isNull();
+        verifyNoInteractions(repo);
+    }
+
+    @Test
+    @DisplayName("clearExclusion removes exclusion; DB resolution resumes")
+    void clearExclusion() {
+        provider.excludeIdentifier(vid("MyLib", "1.0.0"));
+        assertThat(provider.getLibrarySource(vid("MyLib", "1.0.0"))).isNull();
+
+        provider.clearExclusion(vid("MyLib", "1.0.0"));
+        when(repo.findByNameAndVersion("MyLib", "1.0.0"))
+                .thenReturn(Optional.of(entity("MyLib", "1.0.0", "library MyLib version '1.0.0'\n")));
+
+        assertThat(provider.getLibrarySource(vid("MyLib", "1.0.0"))).isNotNull();
+    }
+
+    @Test
+    @DisplayName("returns null + skips DB for unknown + returns null for missing entity")
+    void unknownLibrary_returnsNull() {
+        when(repo.findByNameAndVersion("Missing", "1.0.0")).thenReturn(Optional.empty());
+
+        assertThat(provider.getLibrarySource(vid("Missing", "1.0.0"))).isNull();
+        verify(repo).findByNameAndVersion("Missing", "1.0.0");
+    }
+
+    @Test
+    @DisplayName("latest-version resolution when no version specified")
+    void latestVersionResolution() {
+        when(repo.findByName("MyLib")).thenReturn(List.of(
+                entity("MyLib", "1.0.0", "library MyLib version '1.0.0'\n"),
+                entity("MyLib", "1.2.0", "library MyLib version '1.2.0'\n"),
+                entity("MyLib", "1.1.5", "library MyLib version '1.1.5'\n")
+        ));
+
+        Source out = provider.getLibrarySource(vid("MyLib", null));
+        assertThat(out).isNotNull();
+    }
+}


### PR DESCRIPTION
## Summary

**Addresses code-review issue #4**: \`DatabaseLibrarySourceProvider\` was a silent fallback. BUG-107 happened because a stored copy of a library with the same name+version as the editor's fresh CQL would silently win resolution, running the stale bytes. \`seedCompiledLibrary\` fixed that specific path but offered only one layer of defense — any future flow that bypasses the compiled cache would reintroduce the bug.

This PR adds two structural safeguards so fresh translations always beat stored copies.

關聯 Issue: #231 (risk analysis)

## What changed

### 1. Per-identifier exclusion (hard guarantee)

\`\`\`java
databaseProvider.excludeIdentifier(libraryId);
\`\`\`

- \`DatabaseLibrarySourceProvider.excludeIdentifier(vid)\` suppresses DB resolution for that exact id/version
- When an excluded identifier is requested, we return \`null\` + WARN-log
- Control falls through to the next provider in the chain (typically \`InMemoryLibrarySourceProvider\` holding the user's fresh CQL)
- Applied in \`CqlExecutionService.translateOnce()\` against the just-translated library's identifier
- **Other libraries the CQL includes (DFLR, FHIRHelpers, etc.) remain resolvable from DB normally** — only the actively-translating library is protected

### 2. Observable DB fallback (soft signal)

- Every successful DB lookup now logs INFO with \`name|version\`
- Previously the fallback was completely silent — no way to know it happened
- Going forward, unexpected DB resolutions show up in operator telemetry

### 3. Cleaner factory API

\`LibraryManagerFactory.createContext(repo)\` returns a typed \`LibraryContext\` holder exposing both the \`LibraryManager\` and the \`DatabaseLibrarySourceProvider\` handle. The existing \`create(repo)\` method stays for backward compatibility and delegates.

## Invariants locked in by tests

\`DatabaseLibrarySourceProviderTest\` (new, 8 tests):
- Basic lookup works for known library
- Excluded identifier returns null AND repo is NEVER queried
- Exclusion is identity-specific (LibA excluded → LibB still resolves)
- Exclusion is version-specific (MyLib 1.0.0 excluded → MyLib 2.0.0 still resolves)
- Version-less lookup against an excluded name is also suppressed (defensive — prevents sneak-through via \`SELECT latest version\`)
- \`clearExclusion\` allows DB resolution to resume
- Unknown library returns null cleanly
- Latest-version selection works for multi-version sets

Regression lock: \`CqlExecutionIntegrationTest.freshCql_shouldOverrideSavedDbVersion\` (existing BUG-107 test) still passes → confirms the defense is wired into real-engine execution paths.

## Test plan

- [x] \`mvn test -Dtest='DatabaseLibrarySourceProviderTest,CqlExecutionIntegrationTest'\` → 25/25 pass
- [ ] CI: full backend test + jacoco:check

## Risk

- **Scope**: one provider class, one factory, one caller. Zero changes to scoring / FHIR fetch / engine dispatch.
- **Backward compat**: the old \`LibraryManagerFactory.create(repo)\` method is retained. Callers that don't need the DB provider handle see no change.
- **False-suppression check**: exclusion is keyed by (name, version). Other libraries with different names or versions are unaffected — \`include DFLR version '1.0.0'\` still resolves from DB even when the main \`a1c_dm 1.0.0\` is in the exclusion set.

## IEC 62304 / ISO 14971 追溯

| Ticket | Requirement | Design | Risk | Verification |
|--------|-------------|--------|------|--------------|
| PAT-073 / BUG-113 | — | — | #231 | DatabaseLibrarySourceProviderTest + CqlExecutionIntegrationTest |

🤖 Generated with [Claude Code](https://claude.com/claude-code)