### PR TITLE
fix: deprecate silent-incomplete extractRetrieveTypesFromLibrary(library) overload (#PAT-074)

### DIFF
--- a/backend/src/main/java/com/cqlplatform/service/cql/CqlExecutionService.java
+++ b/backend/src/main/java/com/cqlplatform/service/cql/CqlExecutionService.java
@@ -633,20 +633,39 @@ public class CqlExecutionService {
     }
 
     /**
-     * Extract FHIR retrieve types directly from a pre-translated ELM Library object.
-     * Same-library ExpressionRefs are covered by the outer loop over {@code statements.def};
-     * cross-library ExpressionRefs require resolving the included library via {@code libraryManager}
-     * so we can walk its own ExpressionDefs (otherwise bulk-fetch misses resource types that are
-     * only retrieved inside included libraries — e.g. a main measure that delegates its Initial
-     * Population to an external library containing the actual [Encounter]/[Condition] retrieves).
+     * Extract FHIR retrieve types from a pre-translated ELM Library — legacy single-arg
+     * variant. Does NOT follow cross-library ExpressionRefs, so libraries that delegate
+     * retrieve logic to an included library (e.g. main measure → {@code DFLR."Initial
+     * Population"} → {@code [Encounter]}) will report an INCOMPLETE retrieve set,
+     * leading to silently-wrong bulk-fetch results (BUG-111).
+     *
+     * <p>If the library contains any cross-library ExpressionRef / FunctionRef, this
+     * method emits a loud WARN to make the inevitable wrong-result visible in
+     * operator telemetry. New callers MUST pass a LibraryManager via
+     * {@link #extractRetrieveTypesFromLibrary(org.hl7.elm.r1.Library, LibraryManager)}.
+     *
+     * @deprecated use {@link #extractRetrieveTypesFromLibrary(org.hl7.elm.r1.Library, LibraryManager)}
+     * with a non-null {@code LibraryManager}. This overload exists only for test
+     * scenarios that deliberately exercise the pre-BUG-111 behavior.
      */
+    @Deprecated(forRemoval = true)
     public Set<String> extractRetrieveTypesFromLibrary(org.hl7.elm.r1.Library library) {
+        if (hasCrossLibraryReference(library)) {
+            log.warn("extractRetrieveTypesFromLibrary(library) called on a library that contains "
+                    + "cross-library ExpressionRef/FunctionRef — the returned retrieve-type set is "
+                    + "INCOMPLETE and bulk-fetch will silently miss resource types (BUG-111). "
+                    + "Call the 2-arg overload with a LibraryManager instead. "
+                    + "Library: {}|{}",
+                    library.getIdentifier() != null ? library.getIdentifier().getId() : "?",
+                    library.getIdentifier() != null ? library.getIdentifier().getVersion() : "?");
+        }
         return extractRetrieveTypesFromLibrary(library, null);
     }
 
     /**
-     * Variant that follows cross-library ExpressionRefs through the given LibraryManager.
-     * Passing {@code null} reverts to the legacy behavior (skips cross-lib refs).
+     * Preferred: extract FHIR retrieve types including those reached through cross-library
+     * refs. {@code libraryManager} must be the one used to translate {@code library}; its
+     * compiled-library cache supplies the included library bodies this walker recurses into.
      */
     public Set<String> extractRetrieveTypesFromLibrary(org.hl7.elm.r1.Library library, LibraryManager libraryManager) {
         Set<String> types = new HashSet<>();
@@ -657,6 +676,50 @@ public class CqlExecutionService {
             }
         }
         return types;
+    }
+
+    /**
+     * True when the library contains any {@link org.hl7.elm.r1.ExpressionRef} or
+     * {@link org.hl7.elm.r1.FunctionRef} whose {@code libraryName} is non-null — i.e. a
+     * reference into an included library. Used by the deprecated single-arg
+     * {@link #extractRetrieveTypesFromLibrary(org.hl7.elm.r1.Library)} to warn when the
+     * result will be silently incomplete.
+     */
+    private static boolean hasCrossLibraryReference(org.hl7.elm.r1.Library library) {
+        if (library == null || library.getStatements() == null
+                || library.getStatements().getDef() == null) {
+            return false;
+        }
+        for (org.hl7.elm.r1.ExpressionDef def : library.getStatements().getDef()) {
+            if (containsCrossLibRef(def.getExpression())) return true;
+        }
+        return false;
+    }
+
+    private static boolean containsCrossLibRef(org.hl7.elm.r1.Element element) {
+        if (element == null) return false;
+        if (element instanceof org.hl7.elm.r1.ExpressionRef ref) {
+            if (ref.getLibraryName() != null) return true;
+            // ExpressionRef without libraryName is same-library — no descent needed.
+        }
+        if (element instanceof org.hl7.elm.r1.Query query) {
+            if (query.getSource() != null) {
+                for (var src : query.getSource()) if (containsCrossLibRef(src.getExpression())) return true;
+            }
+            if (query.getWhere() != null && containsCrossLibRef(query.getWhere())) return true;
+        } else if (element instanceof org.hl7.elm.r1.FunctionRef funcRef) {
+            if (funcRef.getLibraryName() != null) return true;
+            if (funcRef.getOperand() != null) {
+                for (var op : funcRef.getOperand()) if (containsCrossLibRef(op)) return true;
+            }
+        } else if (element instanceof org.hl7.elm.r1.UnaryExpression ue) {
+            return containsCrossLibRef(ue.getOperand());
+        } else if (element instanceof org.hl7.elm.r1.BinaryExpression be) {
+            for (var op : be.getOperand()) if (containsCrossLibRef(op)) return true;
+        } else if (element instanceof org.hl7.elm.r1.NaryExpression ne) {
+            for (var op : ne.getOperand()) if (containsCrossLibRef(op)) return true;
+        }
+        return false;
     }
 
     private void collectRetrieveTypes(org.hl7.elm.r1.Element element, Set<String> types) {

--- a/backend/src/test/java/com/cqlplatform/service/cql/CqlExecutionIntegrationTest.java
+++ b/backend/src/test/java/com/cqlplatform/service/cql/CqlExecutionIntegrationTest.java
@@ -498,6 +498,7 @@ class CqlExecutionIntegrationTest {
 
         @Test
         @DisplayName("extractRetrieveTypesFromLibrary follows cross-library ExpressionRef into included library")
+        @SuppressWarnings("removal")
         void crossLibraryRef_shouldDiscoverRetrievesInIncludedLib() {
             // Arrange: included library that declares [Encounter] and [Condition] retrieves
             String includedCql = "library ExternalLib version '1.0.0'\n"
@@ -541,6 +542,81 @@ class CqlExecutionIntegrationTest {
             assertThat(typesWithLibMgr)
                     .contains("Observation")
                     .contains("Encounter");  // now discovered via EL."Qualifying Encounters"
+        }
+
+        @Test
+        @DisplayName("deprecated single-arg overload emits WARN when library has cross-library refs (regression lock for silent-wrong-result)")
+        @SuppressWarnings("removal")
+        void legacySingleArg_shouldWarnOnCrossLibraryReference() {
+            // Attach a Logback ListAppender to capture log events from CqlExecutionService
+            ch.qos.logback.classic.Logger logger =
+                    (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(CqlExecutionService.class);
+            ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent> appender =
+                    new ch.qos.logback.core.read.ListAppender<>();
+            appender.start();
+            logger.addAppender(appender);
+
+            try {
+                // Same setup as above — MainLib references ExternalLib's define
+                String includedCql = "library ExternalLib version '1.0.0'\n"
+                        + "using FHIR version '4.0.1'\ncontext Patient\n"
+                        + "define \"Qualifying Encounters\": [Encounter]\n";
+                com.cqlplatform.entity.CqlLibraryEntity includedEntity = new com.cqlplatform.entity.CqlLibraryEntity();
+                includedEntity.setName("ExternalLib");
+                includedEntity.setVersion("1.0.0");
+                includedEntity.setCqlContent(includedCql);
+                lenient().when(libraryRepository.findByNameAndVersion("ExternalLib", "1.0.0"))
+                        .thenReturn(Optional.of(includedEntity));
+                lenient().when(libraryRepository.findByName("ExternalLib"))
+                        .thenReturn(List.of(includedEntity));
+
+                String mainCql = "library MainWarnLib version '1.0.0'\n"
+                        + "using FHIR version '4.0.1'\n"
+                        + "include ExternalLib version '1.0.0' called EL\n"
+                        + "context Patient\n"
+                        + "define \"IP\": exists(EL.\"Qualifying Encounters\")\n";
+
+                CqlExecutionService.PreTranslatedContext ctx = executionService.translateOnce(mainCql);
+
+                // Act: call the deprecated 1-arg overload
+                executionService.extractRetrieveTypesFromLibrary(ctx.elmLibrary());
+
+                // Assert: a WARN about BUG-111 / incomplete retrieve set must have been logged.
+                // This lock prevents future "helpful" refactors from silencing the warning.
+                assertThat(appender.list).anyMatch(ev ->
+                        ev.getLevel() == ch.qos.logback.classic.Level.WARN
+                                && ev.getFormattedMessage().contains("BUG-111")
+                                && ev.getFormattedMessage().contains("INCOMPLETE"));
+            } finally {
+                logger.detachAppender(appender);
+            }
+        }
+
+        @Test
+        @DisplayName("deprecated single-arg overload does NOT warn when library has no cross-library refs (no false alarms)")
+        @SuppressWarnings("removal")
+        void legacySingleArg_shouldNotWarnOnSelfContainedLibrary() {
+            ch.qos.logback.classic.Logger logger =
+                    (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(CqlExecutionService.class);
+            ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent> appender =
+                    new ch.qos.logback.core.read.ListAppender<>();
+            appender.start();
+            logger.addAppender(appender);
+
+            try {
+                String selfContainedCql = "library SelfContained version '1.0.0'\n"
+                        + "using FHIR version '4.0.1'\ncontext Patient\n"
+                        + "define \"Obs\": [Observation]\n";
+                CqlExecutionService.PreTranslatedContext ctx = executionService.translateOnce(selfContainedCql);
+
+                executionService.extractRetrieveTypesFromLibrary(ctx.elmLibrary());
+
+                assertThat(appender.list).noneMatch(ev ->
+                        ev.getLevel() == ch.qos.logback.classic.Level.WARN
+                                && ev.getFormattedMessage().contains("BUG-111"));
+            } finally {
+                logger.detachAppender(appender);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

**Addresses code-review issue #5**: \`extractRetrieveTypesFromLibrary(Library)\` was a silent footgun. The single-arg overload dispatched to \`extractRetrieveTypesFromLibrary(library, null)\` and returned an INCOMPLETE retrieve-type set whenever the library contained cross-library \`ExpressionRef\` / \`FunctionRef\` nodes. Bulk-fetch then silently missed resource types and delivered 0 of each to the engine — exactly the cause-chain behind BUG-111.

## Changes

### 1. Deprecate the footgun

\`\`\`java
@Deprecated(forRemoval = true)
public Set<String> extractRetrieveTypesFromLibrary(Library library) {
    if (hasCrossLibraryReference(library)) {
        log.warn("extractRetrieveTypesFromLibrary(library) called on a library that contains "
                + "cross-library ExpressionRef/FunctionRef — the returned retrieve-type set is "
                + "INCOMPLETE and bulk-fetch will silently miss resource types (BUG-111). "
                + "Call the 2-arg overload with a LibraryManager instead. "
                + "Library: {}|{}", ...);
    }
    return extractRetrieveTypesFromLibrary(library, null);
}
\`\`\`

- \`@Deprecated(forRemoval = true)\` so compilers/IDEs highlight every use
- WARN-log with the BUG-111 tag + "INCOMPLETE" so the silent wrong-result becomes visible in operator telemetry
- **Only warns when the library actually has cross-lib refs** — self-contained libraries don't trigger false alarms

### 2. Helper: detect cross-library refs

New \`hasCrossLibraryReference(library)\` + \`containsCrossLibRef(element)\` static helpers scan the ELM tree for \`ExpressionRef\` / \`FunctionRef\` nodes with non-null \`libraryName\`. Reused from the pattern in the existing \`collectRetrieveTypes\` walker.

### 3. Production callers already use the 2-arg form

Verified via grep:
- \`MeasureEvaluationService.evaluateMeasure\` bulk-fetch path → 2-arg (since PR #221)
- \`CqlExecutionService.executeWithPreTranslated\` auto-prefetch path → 2-arg (since PR #221)
- Only test \`CrossLibraryRetrieveDiscovery.crossLibraryRef_shouldDiscoverRetrievesInIncludedLib\` still calls the 1-arg version — **that's intentional**, it exists to demonstrate and lock in the legacy-wrong behavior. Annotated with \`@SuppressWarnings("removal")\`.

## Regression locks (new tests)

Both test the 1-arg overload's warning behavior via a Logback \`ListAppender\` attached to the \`CqlExecutionService\` logger:

- **\`legacySingleArg_shouldWarnOnCrossLibraryReference\`**: asserts that calling the 1-arg overload on a library with a cross-lib ref emits a WARN containing \`BUG-111\` and \`INCOMPLETE\`. Prevents future "helpful" refactors from silencing the warning.
- **\`legacySingleArg_shouldNotWarnOnSelfContainedLibrary\`**: asserts NO BUG-111 warning for a library with no cross-lib refs. Prevents regression into over-warning.

## Test plan

- [x] \`mvn test -Dtest='CqlExecutionIntegrationTest$CrossLibraryRetrieveDiscovery'\` → **3/3 pass**
- [ ] CI: full backend test + jacoco:check

## Risk

- **Scope**: one method getting a WARN + two small helpers + two new tests. No runtime logic change in production flows.
- **Backward compat**: the 1-arg overload still returns the same value. Only difference: it now logs a warning when called on a cross-lib library. Callers see nothing new unless they parse logs.
- **Deprecation impact**: IDE will show strikethrough on the 1-arg call in the existing test. That call is intentional — test annotated \`@SuppressWarnings("removal")\`.

## Next step — full removal

Once production callers have been verified to only use the 2-arg version across a release cycle (CI warnings would surface any regressions), the deprecated overload can be deleted in a follow-up PR. The \`forRemoval = true\` flag is the signal.

## IEC 62304 / ISO 14971 追溯

| Ticket | Requirement | Design | Risk | Verification |
|--------|-------------|--------|------|--------------|
| PAT-074 | — (test-infrastructure hardening) | — | Inherits #220 (BUG-111 risk analysis) | CrossLibraryRetrieveDiscovery.legacySingleArg_* |

🤖 Generated with [Claude Code](https://claude.com/claude-code)