### PR TITLE
refactor: MeasureComparisonService reads from normalized population table (Phase 2a) (#PAT-076)

### DIFF
--- a/backend/src/main/java/com/cqlplatform/repository/MeasureReportPopulationRepository.java
+++ b/backend/src/main/java/com/cqlplatform/repository/MeasureReportPopulationRepository.java
@@ -2,10 +2,23 @@ package com.cqlplatform.repository;
 
 import com.cqlplatform.entity.MeasureReportPopulationEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface MeasureReportPopulationRepository extends JpaRepository<MeasureReportPopulationEntity, Long> {
 
     List<MeasureReportPopulationEntity> findByMeasureReportGroupIdOrderByOrdinalAsc(Long measureReportGroupId);
+
+    /**
+     * Fetch all populations for every group of a given report in one query (group ordinal, then
+     * population ordinal). Used by consumers that need the full population map per report —
+     * avoids N+1 calls of {@link #findByMeasureReportGroupIdOrderByOrdinalAsc(Long)}.
+     */
+    @Query("SELECT p FROM MeasureReportPopulationEntity p " +
+            "WHERE p.measureReportGroupId IN " +
+            "   (SELECT g.id FROM MeasureReportGroupEntity g WHERE g.measureReportId = :reportId) " +
+            "ORDER BY p.measureReportGroupId ASC, p.ordinal ASC")
+    List<MeasureReportPopulationEntity> findAllForReport(@Param("reportId") Long reportId);
 }

--- a/backend/src/main/java/com/cqlplatform/service/measure/MeasureComparisonService.java
+++ b/backend/src/main/java/com/cqlplatform/service/measure/MeasureComparisonService.java
@@ -1,6 +1,7 @@
 package com.cqlplatform.service.measure;
 
 import com.cqlplatform.entity.MeasureReportEntity;
+import com.cqlplatform.entity.MeasureReportPopulationEntity;
 import com.cqlplatform.model.measure.MeasureComparisonResult;
 import com.cqlplatform.model.measure.MeasureComparisonResult.PeriodSummary;
 import com.cqlplatform.model.measure.MeasureEvaluationResult;
@@ -8,6 +9,7 @@ import com.cqlplatform.model.measure.MeasureEvaluationResult.GroupResult;
 import com.cqlplatform.model.measure.MeasureEvaluationResult.PopulationResult;
 import com.cqlplatform.model.measure.MeasureTrendResult;
 import com.cqlplatform.model.measure.MeasureTrendResult.TrendDataPoint;
+import com.cqlplatform.repository.MeasureReportPopulationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,6 +24,7 @@ import java.util.stream.Collectors;
 public class MeasureComparisonService {
 
     private final MeasureReportService reportService;
+    private final MeasureReportPopulationRepository populationRepository;
 
     public MeasureComparisonResult comparePeriods(Long measureDefinitionId, String measureName,
                                                    LocalDate p1Start, LocalDate p1End,
@@ -123,7 +126,34 @@ public class MeasureComparisonService {
                 .build();
     }
 
+    /**
+     * Population-type → latest count across all groups.
+     *
+     * <p>Phase 2 of ADR-001: prefer the normalized {@code measure_report_population} table
+     * (one query, indexed, SQL-friendly). Fall back to {@code result_json} parsing when the
+     * report has no normalized rows — this covers reports written before Phase 1 deployment
+     * that haven't been picked up by the startup backfill yet. After Phase 3 the fallback
+     * branch becomes unreachable and will be removed.
+     */
     private Map<String, Integer> extractPopulationCounts(MeasureReportEntity report) {
+        if (report.getId() != null) {
+            List<MeasureReportPopulationEntity> rows = populationRepository.findAllForReport(report.getId());
+            if (!rows.isEmpty()) {
+                // Iteration order (group ordinal, then population ordinal) matches the legacy
+                // result_json traversal below — later populations override earlier same-typed ones.
+                Map<String, Integer> counts = new LinkedHashMap<>();
+                for (MeasureReportPopulationEntity p : rows) {
+                    counts.put(p.getPopulationType(), p.getCount() != null ? p.getCount() : 0);
+                }
+                return counts;
+            }
+        }
+        // Transitional fallback — historical reports not yet backfilled.
+        return extractPopulationCountsFromJson(report);
+    }
+
+    /** Legacy result_json path. Removed after Phase 3 of ADR-001. */
+    private Map<String, Integer> extractPopulationCountsFromJson(MeasureReportEntity report) {
         Map<String, Integer> counts = new HashMap<>();
         MeasureEvaluationResult result = report.getEvaluationResult();
         if (result != null && result.getGroups() != null) {

--- a/backend/src/test/java/com/cqlplatform/service/measure/MeasureComparisonServiceTest.java
+++ b/backend/src/test/java/com/cqlplatform/service/measure/MeasureComparisonServiceTest.java
@@ -1,11 +1,13 @@
 package com.cqlplatform.service.measure;
 
 import com.cqlplatform.entity.MeasureReportEntity;
+import com.cqlplatform.entity.MeasureReportPopulationEntity;
 import com.cqlplatform.model.measure.MeasureComparisonResult;
 import com.cqlplatform.model.measure.MeasureEvaluationResult;
 import com.cqlplatform.model.measure.MeasureEvaluationResult.GroupResult;
 import com.cqlplatform.model.measure.MeasureEvaluationResult.PopulationResult;
 import com.cqlplatform.model.measure.MeasureTrendResult;
+import com.cqlplatform.repository.MeasureReportPopulationRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -23,6 +25,10 @@ class MeasureComparisonServiceTest {
 
     @Mock
     private MeasureReportService reportService;
+
+    /** Phase 2 of ADR-001: consumer now reads from normalized table when available. */
+    @Mock
+    private MeasureReportPopulationRepository populationRepository;
 
     @InjectMocks
     private MeasureComparisonService service;
@@ -161,5 +167,75 @@ class MeasureComparisonServiceTest {
         MeasureTrendResult result = service.getTrend(1L, "Test", 2);
 
         assertThat(result.getDataPoints()).hasSize(2);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Phase 2 of ADR-001: normalized-table read path
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    void extractPopulationCounts_shouldPreferNormalizedTable_whenAvailable() {
+        // Report with both normalized rows (returned by populationRepository) AND legacy result_json
+        MeasureReportEntity r = new MeasureReportEntity();
+        r.setId(500L);
+        r.setMeasureScore(0.75);
+        r.setTotalPatients(48);
+        r.setPeriodStart(LocalDate.of(2026, 1, 1));
+        r.setPeriodEnd(LocalDate.of(2026, 12, 31));
+        // Legacy JSON says IP=99 — if the service reads JSON instead of normalized, the test catches it
+        r.setEvaluationResult(MeasureEvaluationResult.builder()
+                .groups(List.of(GroupResult.builder()
+                        .populations(List.of(PopulationResult.builder()
+                                .populationType("initial-population").count(99).build()))
+                        .build()))
+                .build());
+        // Normalized rows say IP=40 — these should win
+        when(populationRepository.findAllForReport(500L)).thenReturn(List.of(
+                MeasureReportPopulationEntity.builder()
+                        .populationType("initial-population").populationId("ip").count(40).ordinal(0).build(),
+                MeasureReportPopulationEntity.builder()
+                        .populationType("denominator").populationId("denom").count(40).ordinal(1).build(),
+                MeasureReportPopulationEntity.builder()
+                        .populationType("numerator").populationId("numer").count(30).ordinal(2).build()
+        ));
+        when(reportService.getReportsForPeriodById(eq(1L), any(), any()))
+                .thenReturn(List.of(r));
+
+        MeasureComparisonResult result = service.comparePeriods(1L, "a1c_dm",
+                LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31),
+                LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31));
+
+        // The normalized row (40) won over the stale JSON (99) — Phase 2 invariant
+        assertThat(result.getPeriod2().getPopulationCounts())
+                .containsEntry("initial-population", 40)
+                .containsEntry("denominator", 40)
+                .containsEntry("numerator", 30);
+    }
+
+    @Test
+    void extractPopulationCounts_shouldFallBackToJson_whenNormalizedRowsAbsent() {
+        // Represents a report from before Phase 1 deploy, not yet backfilled
+        MeasureReportEntity r = new MeasureReportEntity();
+        r.setId(501L);
+        r.setMeasureScore(0.5);
+        r.setPeriodStart(LocalDate.of(2026, 1, 1));
+        r.setPeriodEnd(LocalDate.of(2026, 12, 31));
+        r.setEvaluationResult(MeasureEvaluationResult.builder()
+                .groups(List.of(GroupResult.builder()
+                        .populations(List.of(
+                                PopulationResult.builder().populationType("initial-population").count(10).build(),
+                                PopulationResult.builder().populationType("numerator").count(5).build()))
+                        .build()))
+                .build());
+        when(populationRepository.findAllForReport(501L)).thenReturn(List.of());  // empty → fallback
+        when(reportService.getReportsForPeriodById(eq(1L), any(), any())).thenReturn(List.of(r));
+
+        MeasureComparisonResult result = service.comparePeriods(1L, "legacy",
+                LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31),
+                LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31));
+
+        assertThat(result.getPeriod2().getPopulationCounts())
+                .containsEntry("initial-population", 10)
+                .containsEntry("numerator", 5);
     }
 }


### PR DESCRIPTION
## Summary

**Phase 2a of ADR-001**: first consumer migration to the normalized \`measure_report_population\` table (Phase 1 landed in PR #235). DashboardService was already independent of \`result_json\` — it's effectively already migrated. So MeasureComparisonService becomes the first real migration target.

Depends on PR #235 (Phase 1 schema + dual-write + backfill).

## Changes

### MeasureReportPopulationRepository

New query:
\`\`\`java
@Query("SELECT p FROM MeasureReportPopulationEntity p " +
        "WHERE p.measureReportGroupId IN " +
        "   (SELECT g.id FROM MeasureReportGroupEntity g WHERE g.measureReportId = :reportId) " +
        "ORDER BY p.measureReportGroupId ASC, p.ordinal ASC")
List<MeasureReportPopulationEntity> findAllForReport(@Param("reportId") Long reportId);
\`\`\`

One query per report → avoids N+1 across groups. Ordered to match the legacy result_json traversal.

### MeasureComparisonService

\`extractPopulationCounts(report)\`:
1. **Preferred**: \`populationRepository.findAllForReport(report.getId())\`. If rows exist, build the type→count map from them.
2. **Fallback** (\`extractPopulationCountsFromJson\`): legacy path that parses \`report.getEvaluationResult().getGroups()\`. Used when:
   - Report has null id (not yet persisted — exists for defensive code paths)
   - No normalized rows found (historical report predating Phase 1 deploy AND backfill hasn't run yet)

The fallback branch is marked for removal in Phase 3 after a full release cycle confirms backfill + dual-write are 100% reliable.

### Tests

- Existing tests: unchanged. They don't stub the new repository, which causes \`findAllForReport\` to return \`null\` / empty default → fallback path executes → same behavior as before Phase 2 → tests still pass.
- 2 new tests:
  - \`extractPopulationCounts_shouldPreferNormalizedTable_whenAvailable\`: plants deliberately WRONG counts in \`result_json\` (IP=99) and correct counts in the repo mock (IP=40). Asserts the returned map has 40 — proves the normalized path wins when both are available. This is the invariant under test.
  - \`extractPopulationCounts_shouldFallBackToJson_whenNormalizedRowsAbsent\`: mock repo returns empty; JSON-only report produces the right counts. Covers the transitional case.

## Test plan

- [x] \`mvn test -Dtest=MeasureComparisonServiceTest\` → **8/8 pass**
- [x] \`mvn test\` full suite → **1133/1133 pass, 0 failures**
- [ ] CI: Backend Tests + jacoco:check
- [ ] VM smoke: run period comparison, verify population delta is correct; confirm by checking DB that \`measure_report_population\` rows were read

## Risk

- **Scope**: one repository method + one service method + two test additions. Zero schema change.
- **Backward compat**: fallback path preserves exact legacy behavior for reports without normalized rows. No user-visible regression even if Phase 1 backfill hasn't run.
- **Regression risk**: the new tests prove normalized-wins-over-json and fallback-works-when-empty. Any future refactor breaks one of these and the invariant fails loudly.

## Next Phase 2 PRs (same pattern, different service)

3. \`MeasureReportExportService\` (PDF / Excel exports — reads groups + stratifiers)
4. \`QrdaExportService\` (QRDA XML — reads groups + populations + stratifiers)
5. \`CompositeMeasureService\` (aggregates population counts across measures)
6. \`HqmfExportService\` (HQMF XML)

## IEC 62304 / ISO 14971 追溯

| Ticket | Requirement | Design | Risk | Verification |
|--------|-------------|--------|------|--------------|
| PAT-076 Phase 2a | (continues #227) | ADR-001 | Low — read-side only, fallback preserved | MeasureComparisonServiceTest new scenarios |

🤖 Generated with [Claude Code](https://claude.com/claude-code)