### PR TITLE
refactor: QrdaExportService normalized read + Phase 2 conclusion (#PAT-076)

### DIFF
--- a/backend/src/main/java/com/cqlplatform/service/measure/QrdaExportService.java
+++ b/backend/src/main/java/com/cqlplatform/service/measure/QrdaExportService.java
@@ -22,6 +22,14 @@ import static com.cqlplatform.model.measure.PopulationTypeConstants.*;
 @Slf4j
 public class QrdaExportService {
 
+    /** Phase 2 of ADR-001: prefer normalized tables over result_json for read. */
+    private final NormalizedMeasureReportReader reportReader;
+
+    private MeasureEvaluationResult loadResult(MeasureReportEntity report) {
+        return reportReader.reconstruct(report.getId())
+                .orElseGet(report::getEvaluationResult);
+    }
+
     private static final Map<String, String> POPULATION_TYPE_OIDS = Map.of(
             INITIAL_POPULATION, "2.16.840.1.113883.10.20.27.3.14",
             DENOMINATOR, "2.16.840.1.113883.10.20.27.3.15",
@@ -94,7 +102,7 @@ public class QrdaExportService {
         xml.append("          <code code=\"55186-1\" codeSystem=\"2.16.840.1.113883.6.1\"/>\n");
         xml.append("          <title>Measure Section</title>\n");
 
-        MeasureEvaluationResult result = report.getEvaluationResult();
+        MeasureEvaluationResult result = loadResult(report);
         if (result != null && result.getGroups() != null) {
             for (GroupResult group : result.getGroups()) {
                 xml.append("          <entry>\n");


### PR DESCRIPTION
## Summary

**Phase 2c — final consumer migration per ADR-001.** Concludes Phase 2 with the QrdaExportService migration plus an audit confirming no other consumers need migration.

Depends on PR #237 (NormalizedMeasureReportReader).

## Changes

### QrdaExportService
- Added constructor dependency: \`NormalizedMeasureReportReader\`
- New private \`loadResult(report)\` method — reader first, fallback via method reference
- Single occurrence of \`report.getEvaluationResult()\` replaced with \`loadResult(report)\` in \`exportQrdaIII\`

## Audit: remaining potential consumers

Reviewed every call site of \`getEvaluationResult()\` / \`MeasureEvaluationResult\` to confirm no migration backlog:

| File | Status | Why |
|------|--------|-----|
| CompositeMeasureService | **Skipped** | Operates on in-memory \`List<MeasureEvaluationResult>\` passed by evaluator; never loads from DB |
| HqmfExportService | **Skipped** | Exports \`MeasureDefinition\` structure (CQL, populations definition); never touches evaluation result |
| MeasureComparisonService | Migrated PR #236 | One remaining \`getEvaluationResult()\` is in the intentional fallback method — stays until Phase 3 |
| MeasureReportBackfillService | Kept | Reads result to re-persist into normalized tables — this IS the source-of-truth path during transition |

## Phase 2 status table (per ADR-001)

| Consumer | Status | PR |
|----------|--------|-----|
| DashboardService | Already independent | — |
| MeasureComparisonService | ✅ | #236 |
| MeasureReportExportService | ✅ | #237 |
| **QrdaExportService** | ✅ **this PR** | — |
| CompositeMeasureService | N/A | — |
| HqmfExportService | N/A | — |

## Test plan

- [x] \`mvn test\` full suite → **1140/1140 pass, 0 failures**
- [ ] CI: Backend Tests + jacoco:check
- [ ] VM smoke: export a QRDA III report, confirm XML bytes match legacy output

## Phase 3 readiness

With Phase 2 done, after one release cycle of dual-write + backfill running successfully:

1. \`MeasureReportEntity.@PostLoad → MeasureEvaluationResult\` deserialization becomes unused by production reads. Only MeasureReportBackfillService still touches it, and that service exists solely for Phase 2 transition.
2. \`result_json\` column becomes safely droppable.
3. Phase 3 PR removes:
   - \`MeasureReportBackfillService\` (no new un-backfilled rows after release 1)
   - \`MeasureReportEntity.@PostLoad + evaluationResult\` transient field
   - \`result_json\` column (Flyway V??)
   - Fallback branches in MeasureComparisonService (\`extractPopulationCountsFromJson\`) / MeasureReportExportService / QrdaExportService (\`loadResult\`'s \`orElseGet\`)

## Risk

- **Scope**: 9 lines added, 1 line changed in QrdaExportService. Zero schema change, zero new classes.
- **Backward compat**: fallback preserved. Legacy reports without normalized rows still render correctly.
- **Test coverage**: exercised transitively by existing QrdaExportServiceTest (which uses @InjectMocks — the new field injects correctly, and without a stub \`reconstruct()\` returns \`Optional.empty()\` → fallback path executes → same behavior as before).

## IEC 62304 / ISO 14971 追溯

| Ticket | Requirement | Design | Risk | Verification |
|--------|-------------|--------|------|--------------|
| PAT-076 Phase 2c | (continues #227) | ADR-001 | Low — 1-line read-path change with preserved fallback | 1140/1140 test suite |

🤖 Generated with [Claude Code](https://claude.com/claude-code)