### PR TITLE
feat: landing page footer contact email (#PAT-105)

### DIFF
--- a/frontend/src/locales/en/landing.json
+++ b/frontend/src/locales/en/landing.json
@@ -719,5 +719,8 @@
       "reset": "Reset Progress",
       "resetConfirm": "Are you sure you want to reset all learning progress?"
     }
+  },
+  "footer": {
+    "contactPrompt": "Business inquiries / bug reports:"
   }
 }

--- a/frontend/src/locales/zh-TW/landing.json
+++ b/frontend/src/locales/zh-TW/landing.json
@@ -719,5 +719,8 @@
       "reset": "重設進度",
       "resetConfirm": "確定要重設所有學習進度嗎？"
     }
+  },
+  "footer": {
+    "contactPrompt": "商業合作 / 錯誤回報："
   }
 }

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -228,6 +228,27 @@ export default function LandingPage() {
             </Typography>
           ))}
         </Box>
+        <Typography
+          variant="caption"
+          sx={(theme) => ({
+            display: 'block',
+            mb: 0.5,
+            color: alpha(theme.palette.common.white, 0.5),
+          })}
+        >
+          {t('footer.contactPrompt')}{' '}
+          <Box
+            component="a"
+            href="mailto:aluminum001@gmail.com"
+            sx={(theme) => ({
+              color: alpha(theme.palette.common.white, 0.75),
+              textDecoration: 'none',
+              '&:hover': { color: theme.palette.primary.light, textDecoration: 'underline' },
+            })}
+          >
+            aluminum001@gmail.com
+          </Box>
+        </Typography>
         <Typography variant="caption" sx={(theme) => ({ color: alpha(theme.palette.common.white, 0.35) })}>
           {tc('app.title')} — Clinical Quality Language
         </Typography>


### PR DESCRIPTION
## Summary

Adds a contact line to the `LandingPage` footer so visitors can reach out for business cooperation or bug reports.

- Location: above the existing copyright caption in the page footer
- Email: `aluminum001@gmail.com` as a `mailto:` link
- i18n: new `footer.contactPrompt` key in `landing` namespace

## i18n

| Locale | Value |
|---|---|
| en | Business inquiries / bug reports: |
| zh-TW | 商業合作 / 錯誤回報： |

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Visual verification after deploy: visit https://twcql.com/, scroll to footer, confirm email appears and clicking it opens the mail client

Refs: #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)