### PR TITLE
fix: map RejectedExecutionException to 503 (#PAT-109 follow-up)

### DIFF
--- a/backend/src/main/java/com/cqlplatform/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/cqlplatform/exception/GlobalExceptionHandler.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.RejectedExecutionException;
 
 @RestControllerAdvice
 @Slf4j
@@ -109,6 +110,24 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
         return buildResponse(HttpStatus.BAD_REQUEST, "Bad Request", ex.getMessage());
+    }
+
+    // Thrown when an AbortPolicy-backed thread pool is saturated. Today that's
+    // patientImportExecutor (bulk EHR import). 503 + Retry-After lets the client
+    // back off rather than interpret a 500 as a platform bug.
+    @ExceptionHandler(RejectedExecutionException.class)
+    public ResponseEntity<ErrorResponse> handleRejectedExecutionException(RejectedExecutionException ex) {
+        log.warn("Task rejected by executor (pool saturated): {}", ex.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.SERVICE_UNAVAILABLE)
+                .header("Retry-After", "30")
+                .body(ErrorResponse.builder()
+                        .timestamp(LocalDateTime.now())
+                        .status(HttpStatus.SERVICE_UNAVAILABLE.value())
+                        .error("Service Overloaded")
+                        .message("The server is currently handling too many concurrent requests. Please retry in a few seconds.")
+                        .requestId(MDC.get("requestId"))
+                        .build());
     }
 
     @ExceptionHandler(Exception.class)

--- a/backend/src/test/java/com/cqlplatform/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/cqlplatform/exception/GlobalExceptionHandlerTest.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 
 import java.util.List;
+import java.util.concurrent.RejectedExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -177,6 +178,29 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().getStatus()).isEqualTo(400);
         assertThat(response.getBody().getMessage()).isEqualTo("Invalid FHIR resource type");
+    }
+
+    // ===== RejectedExecutionException → 503 with Retry-After =====
+    // PAT-109: when patientImportExecutor AbortPolicy rejects a bulk-import submit,
+    // the API should return a retry-able 503 rather than the generic 500 fallback.
+
+    @Test
+    void handleRejectedExecutionException_shouldReturn503WithRetryAfterHeader() {
+        RejectedExecutionException ex = new RejectedExecutionException(
+                "Task rejected from ThreadPoolExecutor[...]");
+
+        ResponseEntity<GlobalExceptionHandler.ErrorResponse> response =
+                handler.handleRejectedExecutionException(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(response.getHeaders().getFirst("Retry-After")).isEqualTo("30");
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(503);
+        assertThat(response.getBody().getError()).isEqualTo("Service Overloaded");
+        assertThat(response.getBody().getMessage())
+                .as("user-facing message must be retry-oriented, not leak internals like 'ThreadPoolExecutor'")
+                .contains("retry")
+                .doesNotContain("ThreadPoolExecutor");
     }
 
     // ===== Generic Exception → 500, no leak =====


### PR DESCRIPTION
## 變更說明

PAT-109 的遺漏補丁。PR #358 的 auto-merge 先於我推這個 commit 前觸發，導致它留在 stale branch 未進 main。

當 `patientImportExecutor` (AbortPolicy) 飽和時，submit 拋 `RejectedExecutionException`。沒 handler 會走 generic 500 fallback。此 PR 加 `@ExceptionHandler(RejectedExecutionException.class)` → HTTP 503 + `Retry-After: 30` + `error: "Service Overloaded"`，讓客戶端正確 backoff。

訊息為使用者導向（"retry in a few seconds"），不洩漏 `ThreadPoolExecutor` 內部字眼。

## 關聯 Issue

Refs #357（PAT-109 需求）、#362（設計描述此 503 映射）、#364（驗證鎖住此契約）

## 測試紀錄

- `GlobalExceptionHandlerTest`: 13/13 pass（新 1 + 既有 12 回歸）
- 新 test 斷言：503 status、`Retry-After: 30` header、使用者訊息含 "retry" 且不含 "ThreadPoolExecutor"

## 風險評估

- 純新增：既有 12 個 exception handler 不動
- 觸發情境只在 AbortPolicy 飽和時，production 下是系統過載徵兆（目前 patient import 專用）
- 無 DB migration、無 API contract 破壞、無 FE 改動

## IEC 62304 / ISO 14971 追溯

| 需求 | 設計 | 風險 | 驗證 |
|------|------|------|------|
| #357 | #362 | #363 | #364 |

安全性等級：**B**（承接 PAT-109 主 PR；此補丁為其設計章節明列的行為之一）

🤖 Generated with [Claude Code](https://claude.com/claude-code)