### PR TITLE
docs: post-PAT112 deployment / API / runbook sync

### DIFF
--- a/DEPLOYMENT_GUIDE_zh-TW.md
+++ b/DEPLOYMENT_GUIDE_zh-TW.md
@@ -180,6 +180,32 @@ docker compose up -d --build
 |------|------|--------|
 | `GF_SECURITY_ADMIN_USER` | Grafana 管理員帳號 | `admin` |
 | `GF_SECURITY_ADMIN_PASSWORD` | Grafana 管理員密碼 | **必須設定** |
+| `METRICS_SCRAPE_USER` | Prometheus scrape HTTP Basic username | `prometheus` |
+| `METRICS_SCRAPE_PASSWORD` | Prometheus scrape HTTP Basic password（PAT-113） | **必須設定** |
+
+> **⚠️ PAT-113 之後**：`/actuator/prometheus` 預設要求 HTTP Basic 認證。`METRICS_SCRAPE_PASSWORD` 未設 → prometheus container 啟動時 FATAL exit，整個監控鏈斷掉（但 backend / frontend 不受影響）。
+>
+> 產生指令：
+> ```bash
+> openssl rand -base64 24
+> ```
+> 把輸出值填入 `.env` 的 `METRICS_SCRAPE_PASSWORD=`。`METRICS_SCRAPE_USER` 可留 `prometheus` 預設值。兩個變數的值必須在 backend 和 prometheus 兩個 container 之間一致（docker-compose 都從同一個 `.env` 讀）。
+
+### 4.6 Thread pool 調校（PAT-109）
+
+Backend 有兩個主要 thread pool：CQL 執行池（同步 API）與 bulk patient import 池（背景 EHR 匯入）。兩者刻意獨立以避免 bulk import 癱瘓 API。
+
+| 變數 | 說明 | 預設值 |
+|------|------|--------|
+| `RATE_LIMIT_TRANSLATE_RPM` | CQL 翻譯 per-IP 速率 | `20` |
+| `RATE_LIMIT_EXECUTE_RPM` | CQL 執行 per-IP 速率 | `10` |
+| `RATE_LIMIT_FIX_SUGGESTION_RPM` | AI 修正建議 per-IP 速率 | `5` |
+| `RATE_LIMIT_CDS_DISCOVERY_RPM` | CDS discovery 端點 per-IP 速率（PAT-107） | `20` |
+| `EHR_IMPORT_THREAD_POOL_SIZE` | Bulk import 核心 thread 數 | `4` |
+| `EHR_IMPORT_MAX_POOL_SIZE` | Bulk import 最大 thread 數 | `8` |
+| `EHR_IMPORT_QUEUE_CAPACITY` | Bulk import queue 容量 | `100` |
+
+> **調校時機**：Grafana 的「Patient Import Pool」panel 顯示 queue depth 持續接近 80、或 HikariCP `pending` > 3 持續數分鐘，代表 pool 飽和，可上調對應變數。調大前先確認資料庫 `max_connections`（預設 100）還夠用。
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -49,13 +49,85 @@ Authorization: Bearer <token>
 
 ### 錯誤處理
 
-錯誤回應格式：
+所有錯誤回應走統一的 `ErrorResponse` envelope（`GlobalExceptionHandler`）：
 
 ```json
 {
-  "error": "錯誤訊息描述"
+  "timestamp": "2026-04-24T10:15:30.123",
+  "status": 503,
+  "error": "FHIR Server Unavailable",
+  "message": "Human-readable explanation",
+  "details": ["optional validation error list"],
+  "requestId": "uuid-for-log-correlation",
+  "errorType": "FHIR_UPSTREAM_UNAVAILABLE",
+  "upstream": {
+    "connectionId": 42,
+    "connectionName": "Taipei General FHIR",
+    "reason": "TIMEOUT",
+    "retryAfterSeconds": 30
+  },
+  "errorInfo": {
+    "phase": "cql_translation",
+    "errorType": "CqlTranslationException",
+    "message": "...",
+    "stackTraceSummary": ["..."]
+  }
 }
 ```
+
+欄位說明：
+
+| 欄位 | 何時出現 | 說明 |
+|------|----------|------|
+| `timestamp` / `status` / `error` / `message` | 一律有 | 基本錯誤資訊 |
+| `details` | 驗證錯誤 | Multi-line validation errors |
+| `requestId` | 一律有 | 對應 log 的 MDC `requestId` |
+| `errorType` | 結構化錯誤類別 | 目前只有 `"FHIR_UPSTREAM_UNAVAILABLE"`（PAT-110），其他錯誤此欄位省略 |
+| `upstream` | `errorType="FHIR_UPSTREAM_UNAVAILABLE"` 時 | 見下方 |
+| `errorInfo` | CQL 執行 / measure 評估錯誤 | 見下方 |
+
+#### `upstream` 結構（PAT-110）
+
+當 FHIR 上游服務失敗時（timeout、5xx、circuit breaker open、連線拒絕等），回應會包含結構化的 `upstream` 物件供前端判別、渲染黃色「EHR 暫時離線」banner：
+
+| 欄位 | 型別 | 說明 |
+|------|------|------|
+| `connectionId` | `number \| null` | 失敗的 EHR 連線 id；null 代表錯誤無法歸屬到特定連線（translation-time VSAC 查詢、背景工作等） |
+| `connectionName` | `string \| null` | 連線的人類可讀名稱 |
+| `reason` | `string` | `TIMEOUT` \| `CIRCUIT_BREAKER_OPEN` \| `UPSTREAM_5XX` \| `CONNECTION_REFUSED` \| `OTHER` |
+| `retryAfterSeconds` | `number` | 建議重試秒數；鏡射 `Retry-After` HTTP header |
+
+同時設定 `Retry-After: 30`（upstream error）或 `Retry-After: 60`（breaker open）HTTP header。
+
+**客戶端判別建議**：
+- 收到 503 + `errorType="FHIR_UPSTREAM_UNAVAILABLE"` → 顯示「EHR 暫時離線」非平台故障；按 `retryAfterSeconds` 自動 backoff
+- 收到 503 **未帶** `errorType` → 視為平台一般錯誤
+
+#### `errorInfo` 結構
+
+CQL 執行 / CDS 呼叫 / measure 評估錯誤會附帶 `errorInfo`：
+
+| 欄位 | 說明 |
+|------|------|
+| `phase` | `cql_translation` / `cql_execution` / `fhir_retrieval` / `population_evaluation` / ... |
+| `errorType` | 內部例外類別 simple name |
+| `message` | 錯誤訊息 |
+| `stackTraceSummary` | `com.cqlplatform.*` 的 top 5 stack frames |
+
+### 速率限制
+
+當 per-IP 或 per-user 速率超過時：
+
+```http
+HTTP/1.1 429 Too Many Requests
+Retry-After: 30
+```
+
+Body 同 `ErrorResponse`、`error` 欄位含 `"Rate limit exceeded"`。
+
+### 服務過載
+
+當 bulk-import thread pool 飽和觸發 `AbortPolicy`（PAT-109），回 503 + `Retry-After: 30` + `error="Service Overloaded"`。客戶端應 backoff 不視為平台故障。
 
 ### 角色權限
 
@@ -1188,6 +1260,63 @@ Body: MeasureEvaluationRequest（含 measureCql）。
 | `/api/ehr/connections/{id}/patients/{patientId}/preview` | GET | 匯入預覽 |
 | `/api/ehr/connections/{id}/patients/{patientId}/import?measureId=` | POST | 匯入病患資料為測試案例（201） |
 | `/api/ehr/imports?importedBy=` | GET | 匯入歷史 |
+
+---
+
+### 8.3 連線健康狀態（PAT-111）
+
+提供背景排程健康檢查的結果，前端 `EhrConnectionList` 的「Live Health」欄位消費這些端點（每 30 秒 poll）。
+
+| 端點 | 方法 | 說明 |
+|------|------|------|
+| `/api/ehr/health/overview` | GET | 所有連線的當前健康狀態（array） |
+| `/api/ehr/health/connections/{id}/history?hours=24` | GET | 特定連線的歷史健康檢查紀錄 |
+| `/api/ehr/health/circuit-breakers` | GET | Resilience4j 斷路器即時狀態（list，by breaker instance name） |
+
+#### `GET /api/ehr/health/overview` 回應
+
+```json
+[
+  {
+    "connectionId": 42,
+    "connectionName": "Taipei General FHIR",
+    "fhirServerUrl": "https://fhir.example.com/r4",
+    "currentStatus": "healthy",
+    "lastResponseTimeMs": 125,
+    "lastCheckedAt": "2026-04-24T10:15:00",
+    "avgResponseTimeMs24h": 143.7,
+    "availability24h": 99.5,
+    "totalChecks24h": 96,
+    "errorCount24h": 0
+  }
+]
+```
+
+`currentStatus` 可能值：
+- `healthy` — 最近檢查成功
+- `degraded` — 回應但時間過長（見 `avgResponseTimeMs24h`）
+- `down` — 最近檢查失敗
+- `unknown` — 尚未執行過檢查
+
+背景健康檢查間隔由 `EHR_HEALTH_CHECK_MINUTES` env 控制（預設 15 分鐘），紀錄保留期間由 `EHR_HEALTH_RETENTION_DAYS`（預設 7 天）控制。
+
+#### `GET /api/ehr/health/circuit-breakers` 回應
+
+```json
+[
+  {
+    "name": "fhirDataProvider",
+    "state": "CLOSED",
+    "failureRate": 0.0,
+    "slowCallRate": 0.0,
+    "bufferedCalls": 10,
+    "failedCalls": 0,
+    "successfulCalls": 10
+  }
+]
+```
+
+`state` 可能值：`CLOSED`（正常）/ `OPEN`（熔斷中，拒絕請求）/ `HALF_OPEN`（試探性放行）。注意 `name` 是 breaker instance 名稱（如 `fhirDataProvider`、`fhirTerminology`、`vsacService`），**不是** connection id — 若需按連線對應，需自行 cross-reference。
 
 ---
 

--- a/docs/runbooks/fhir-server-unavailable.md
+++ b/docs/runbooks/fhir-server-unavailable.md
@@ -1,68 +1,134 @@
 # Runbook: FHIR Server Unavailable
 
-## Alert
-`FhirCircuitBreakerOpen` - Circuit breaker has been in OPEN state for >1 minute.
+_Last updated: 2026-04-24 (PAT-110 / PAT-111 / PAT-112 stack)_
 
-## Symptoms
-- API returns 503 Service Unavailable for FHIR-dependent endpoints
-- Circuit breaker metrics show `state=open` in Prometheus
-- Logs show `Circuit breaker fallback` warnings
-- CQL execution and measure evaluation fail
+## What you will see
+
+### User-facing signals (PAT-110)
+- **Yellow persistent banner at the top of the app**: "EHR 'X' is temporarily unavailable". Does NOT auto-dismiss; user clicks to acknowledge.
+- HTTP 503 with structured body on affected endpoints:
+  ```json
+  {
+    "errorType": "FHIR_UPSTREAM_UNAVAILABLE",
+    "upstream": {
+      "connectionId": 42,
+      "connectionName": "Taipei General FHIR",
+      "reason": "CIRCUIT_BREAKER_OPEN",
+      "retryAfterSeconds": 60
+    },
+    "message": "FHIR service is temporarily unavailable due to repeated failures."
+  }
+  ```
+- `Retry-After` header set to 30 or 60 seconds.
+
+### Admin-facing signals (PAT-111)
+- `EhrConnectionList` table (admin settings) shows the affected connection with a **red "Down" chip** + availability %. Polls every 30s.
+- Hover tooltip shows: 24h availability, avg response ms, error count 24h, last checked timestamp.
+
+### Behavior differences from earlier versions (PAT-112a/b/c)
+- **CDS Hooks**: on FHIR outage, returns 5xx. Does **not** return an empty `cards: []` response — an empty card would look identical to "no alert needed" and hide the outage from clinicians.
+- **Measure evaluation**: on FHIR outage during any patient in a batch, the entire evaluation aborts with `errorResult`. Does **not** partial-aggregate — a partial denominator falsifies the quality score.
+- **Prefetch parse failures** (PAT-112b): any single bad prefetch key fails the whole CDS invocation. The failed key is still recorded in `diagnostics.prefetchStatus[*].status=failed` so the EHR integration team can see which key broke.
+- **HAPI 200-with-OperationOutcome-error** (PAT-112c): detected and treated as outage, not as empty data.
+
+## Alerts that fire
+
+| Alert | Severity | Condition | Runbook action |
+|-------|----------|-----------|----------------|
+| `FhirCircuitBreakerOpen` | critical | any breaker `state=open` for >1m | this runbook |
+| `HighFhirRetryRate` | warning | `rate(resilience4j_retry_calls_total{kind="successful_with_retry"}[5m]) > 0.5` for 3m | upstream degrading; monitor |
+| `HighErrorRate` | critical | 5xx > 5% for 2m | check whether it's FHIR-upstream 503s (expected during outage) vs. genuine backend bugs |
+| `ServiceDown` | critical | `up{job="cql-platform"}=0` | check Prometheus scrape auth (PAT-113) before assuming backend is dead |
 
 ## Diagnosis
 
-### 1. Check Circuit Breaker State
+### 1. Is it CQL Platform or the FHIR server?
 ```bash
-curl -s http://localhost:8080/actuator/metrics/resilience4j.circuitbreaker.state | jq
+# Admin EHR table — single glance tells you which connection
+# Or via API:
+curl -s -H "Authorization: Bearer <admin-token>" \
+  https://twcql.com/api/ehr/health/overview | jq '.[] | {connectionName, currentStatus, availability24h, lastCheckedAt}'
 ```
 
-### 2. Check FHIR Server Health
-```bash
-# HAPI FHIR server
-curl -f http://hapi-fhir:8080/fhir/metadata
+Output like `{"currentStatus": "down", "availability24h": 15.0}` → upstream is down. Backend is fine.
 
-# External terminology server
-curl -f http://tx.fhir.org/r4/metadata
+### 2. Which EHR connection, which reason?
+Read a recent error envelope:
+```bash
+docker logs docker-backend-1 --tail 500 | grep "FhirServerUnavailableException" | tail -5
+```
+The log message includes the classified `Reason` (TIMEOUT / CIRCUIT_BREAKER_OPEN / UPSTREAM_5XX / CONNECTION_REFUSED / OTHER) and the `connectionId` at the time of throw.
+
+### 3. Circuit-breaker state
+```bash
+# In-process metrics — requires basic auth (PAT-113)
+docker exec docker-prometheus-1 sh -c "wget -q -O- 'http://localhost:9090/api/v1/query?query=resilience4j_circuitbreaker_state'" | jq '.data.result'
+```
+Or query it inline from Grafana's "Resilience4j" dashboard.
+
+### 4. Raw FHIR probe
+```bash
+# From the backend container (same network path as the real retrieve):
+docker exec docker-backend-1 sh -c "wget -q -O- --spider http://hapi-fhir:8080/fhir/metadata"
+# External EHR:
+docker exec docker-backend-1 sh -c "wget -q -O- --spider '<EHR_URL>/metadata'"
 ```
 
-### 3. Check Network Connectivity
+### 5. HAPI-side OperationOutcome (PAT-112c)
+If the metric shows 5xx from CDS/measure but a raw FHIR probe returns 200, suspect HAPI wrapping errors in a 200 + `OperationOutcome(severity=error)`:
 ```bash
-docker exec backend ping -c 3 hapi-fhir
-docker exec backend wget -q --spider http://hapi-fhir:8080/fhir/metadata
+docker logs docker-backend-1 --tail 200 | grep "Upstream returned OperationOutcome error" 
 ```
-
-### 4. Check FHIR Server Logs
-```bash
-docker logs --tail 100 hapi-fhir
-```
-
-### 5. Check Connection Pool
-```bash
-curl -s http://localhost:8080/actuator/metrics/http.client.requests | jq
-```
+If found, the upstream is misbehaving — not us.
 
 ## Resolution
 
-### FHIR Server Down
-1. Check if HAPI FHIR container is running: `docker ps | grep hapi`
-2. Restart if needed: `docker compose restart hapi-fhir`
-3. Wait for health check to pass (~30s)
-4. Circuit breaker will auto-transition to HALF_OPEN after `waitDurationInOpenState` (30s for data, 60s for terminology)
+### Upstream EHR is down
+- **Do not restart backend.** The circuit breaker will auto-transition OPEN → HALF_OPEN → CLOSED when upstream recovers (wait `waitDurationInOpenState`: 30s for `fhirDataProvider`, 60s for `fhirTerminology`).
+- Tell affected users the yellow banner is expected; they should retry after the `Retry-After` hint (30–60s).
+- If upstream stays down >30 min, coordinate with the EHR ops team; consider temporarily routing to a fallback EHR via `FHIR_SERVER_URL` env change + backend restart.
 
-### Network Issues
-1. Verify Docker network: `docker network inspect cql-network`
-2. Restart backend to re-establish connections: `docker compose restart backend`
+### HAPI is running but throwing OperationOutcome errors
+- PAT-112c now surfaces these as outages (previously silent). Check HAPI logs:
+  ```bash
+  docker logs --tail 200 docker-hapi-fhir-1
+  ```
+- Typical causes: HAPI DB timeout, index corruption, JVM GC storm. Restart HAPI:
+  ```bash
+  docker compose -f /opt/CQL/docker/docker-compose.yml restart hapi-fhir
+  ```
 
-### External Terminology Server
-1. Check tx.fhir.org status
-2. If persistently down, switch to local terminology server via `FHIR_TERMINOLOGY_URL` env var
-3. Cached terminology lookups will continue working from Caffeine cache
+### Prefetch parse failures (CDS-only, PAT-112b)
+Symptom: CDS returns 5xx on a specific hook, `diagnostics.prefetchStatus[N].status=failed` in the response body.
+- Root cause is usually EHR-sent JSON that the backend can't deserialize (FHIR version mismatch, custom profile, or charset issue).
+- Look at the `error` field inside `prefetchStatus` for the exception class + message:
+  ```bash
+  docker logs docker-backend-1 --tail 200 | grep "Prefetch key .* failed to parse"
+  ```
+- Fix is on the EHR side (correct the prefetch payload). Backend does not retry.
 
-### Manual Circuit Breaker Reset
-Circuit breakers automatically transition from OPEN -> HALF_OPEN -> CLOSED. No manual intervention needed. Wait for the configured `waitDurationInOpenState`.
+### Partial measure evaluation aborts (PAT-112a)
+Symptom: `POST /api/measures/{id}/$evaluate-measure` returns a result with `status: "error"` and a message "Measure evaluation aborted: upstream FHIR server unavailable during N of M patient evaluations."
+- Design: partial denominators falsify the quality score. The evaluation aborts intentionally once any patient's retrieve fails due to FHIR outage.
+- Resolution: wait for the upstream to recover, then re-trigger evaluation. No data is partially persisted.
+
+### Manual circuit-breaker reset
+Not needed — Resilience4j transitions automatically. If you need to force it (e.g. during a known-good post-incident test), restart the backend:
+```bash
+docker compose -f /opt/CQL/docker/docker-compose.yml restart backend
+```
+This resets all breakers to CLOSED and re-opens them on the first probe failure.
 
 ## Prevention
-- Monitor `resilience4j_circuitbreaker_state` metric
-- Set up alerts for sustained OPEN state
-- Use connection pooling (configured: 20 max, 10 per route)
-- Ensure FHIR server has adequate resources
+
+- Grafana dashboard panels to watch: "HikariCP Connection Pool", "Patient Import Pool", "CQL Execution Pool", "Resilience4j State".
+- `EhrConnectionList` admin UI (PAT-111) gives always-on visibility into per-connection health; schedule it as part of daily check.
+- For EHRs known to be flaky, lower `RATE_LIMIT_CDS_DISCOVERY_RPM` (PAT-107, default 20) to cut enumeration noise.
+- Keep an eye on `measure_report_deserialization_failures` (PAT-108) — unrelated to FHIR outage but fires if historical reports become unreadable, which is a separate silent-data-loss class.
+
+## Related
+
+- `docs/pre-launch-production-readiness-review.md` §#10 — the product/clinical decision record
+- `DEPLOYMENT_GUIDE_zh-TW.md` §4.5 — Prometheus scrape auth setup (PAT-113)
+- `docs/API.md` — `FHIR_UPSTREAM_UNAVAILABLE` envelope shape
+- `docs/secrets-rotation.md` — `METRICS_SCRAPE_PASSWORD` rotation

--- a/docs/secrets-rotation.md
+++ b/docs/secrets-rotation.md
@@ -39,6 +39,7 @@ All secrets are managed via Bitnami Sealed Secrets. Plaintext values live in `sc
 | `OKTA_CLIENT_ID` | Rarely | Only when rotating Okta app |
 | `OKTA_CLIENT_SECRET` | 180 days | Regenerate in Okta admin console |
 | `OKTA_ISSUER` | Rarely | Only if Okta org/auth server changes |
+| `METRICS_SCRAPE_PASSWORD` | 90 days | **See special procedure below** (must stay in sync between backend + prometheus containers) |
 
 ## Special: ENCRYPTION_KEY Rotation
 
@@ -51,6 +52,61 @@ The `ENCRYPTION_KEY` is used to encrypt sensitive data at rest in the database. 
 5. Rotate the secret as per normal procedure
 
 **Do not rotate ENCRYPTION_KEY without completing the re-encryption step**, or encrypted data will become unreadable.
+
+## Special: METRICS_SCRAPE_PASSWORD Rotation (PAT-113)
+
+This secret protects `/actuator/prometheus` with HTTP Basic auth. It is consumed by
+**two containers simultaneously** (`backend` signs auth, `prometheus` scrape sends it),
+so a mid-rotation window where backend has the new password but prometheus has the old
+(or vice versa) causes scrape failures and the `ServiceDown` alert fires. The rotation
+must restart both containers in one shot.
+
+### VM (docker-compose) procedure
+
+```bash
+# 1. SSH in
+ssh root@<VM>
+
+# 2. Generate new secret
+NEW=$(openssl rand -base64 24)
+# Intentionally NOT echoed — prevents the password leaking into shell history
+
+# 3. Update .env atomically (sed -i in-place, no stdout echo)
+cd /opt/CQL/docker
+sed -i "/^METRICS_SCRAPE_PASSWORD=/d" .env
+echo "METRICS_SCRAPE_PASSWORD=$NEW" >> .env
+unset NEW   # scrub from shell env
+
+# 4. Force-recreate both containers (MUST be done together)
+docker compose -f docker-compose.yml up -d --force-recreate prometheus backend
+
+# 5. Verify scrape resumes
+sleep 15
+docker exec docker-prometheus-1 sh -c \
+  "wget -q -O- 'http://localhost:9090/api/v1/query?query=up{job=\"cql-platform\"}'" \
+  | jq '.data.result[0].value[1]'
+# Expected: "1"
+```
+
+### Kubernetes procedure
+
+Update both the backend and prometheus deployments in the same sealed-secrets bundle,
+apply, then:
+```bash
+kubectl rollout restart deployment/backend deployment/prometheus -n cql-platform
+```
+
+### Safety notes
+
+- **Never paste the password on the command line as an argument to `curl -u` or
+  `wget --password=` to verify** — BusyBox (alpine containers) prints unknown flags
+  with their values to stderr, leaking the secret into logs. Trust the Prometheus
+  `up{job="cql-platform"}=1` signal instead.
+- If the rotation fails halfway (backend restarts but prometheus doesn't), the
+  `ServiceDown` alert will fire. This is loud by design. Complete the rotation or
+  roll back both.
+- The password is present in `docker inspect` output — treat the VM's docker socket
+  as secret-sensitive.
 
 ## Special: JWT_SECRET Rotation
 


### PR DESCRIPTION
## 變更說明

最近 7 個 PR (PAT-106/108/109/110/111/112a-c/113) 改動了平台的錯誤行為、部署需求、管理員可視介面。本 PR 把 4 份對應的運維/對接商文件跟著更新。**純文件變更**，無程式碼。

## 四份檔案

### 1. `DEPLOYMENT_GUIDE_zh-TW.md`（§4.5 + 新 §4.6）
- 加 `METRICS_SCRAPE_USER/PASSWORD`（PAT-113 必設）+ 產生指令
- 警告：未設會導致 prometheus container `FATAL exit 1` → CrashLoopBackOff
- 加 `EHR_IMPORT_*` 與 rate-limit 調校變數（PAT-107 + PAT-109）

### 2. `docs/secrets-rotation.md`
- 輪換排程表加 `METRICS_SCRAPE_PASSWORD`（90 天）
- 新 \"Special: METRICS_SCRAPE_PASSWORD Rotation\" 章節同時涵蓋 VM (docker-compose) 與 Kubernetes 路徑
- Safety note 提醒**不要**用 `curl -u` 或 `wget --password=` 驗證 — BusyBox 會把密碼印到 stderr（我昨天踩過的洩漏）

### 3. `docs/runbooks/fhir-server-unavailable.md`（full rewrite）
舊 runbook 是 PAT-110 之前的版本。新版涵蓋：
- 黃色 persistent banner（非紅色 error）
- `EhrConnectionList` admin Live Health 欄位
- CDS 回 5xx **不回空 card**（PAT-112a/b）、Measure 整個 fail **不 partial**（PAT-112a）、Bundle 裡的 OperationOutcome(error) 偵測（PAT-112c）、Prefetch strict mode（PAT-112b）
- 更新 alerts 表（加 `ServiceDown` 提醒 check PAT-113 basic auth、`HighFhirRetryRate` 現在走 resilience4j）
- 診斷步驟改用 `/api/ehr/health/overview` 與 basic-auth-protected Prometheus

### 4. `docs/API.md`
- 統一 `ErrorResponse` envelope 文件，加 `errorType` / `upstream` / `errorInfo` 欄位說明
- `FHIR_UPSTREAM_UNAVAILABLE` envelope 客戶端判別建議
- 429 rate limit + 503 overload（PAT-109 AbortPolicy）行為
- 新 §8.3 連線健康端點（`/api/ehr/health/overview` / `/history` / `/circuit-breakers`），PAT-111 消費的端點

## 測試

N/A — 純文件。

## 風險

- 無。
- 連帶效益：對接商可讀到完整錯誤 envelope 規格、ops 有確定的密碼輪換 / runbook 程序。

🤖 Generated with [Claude Code](https://claude.com/claude-code)