### PR TITLE
fix: IG Browser detail endpoints 400 + VS compose hint (#PAT-119)

### DIFF
--- a/backend/src/main/java/com/cqlplatform/controller/FhirController.java
+++ b/backend/src/main/java/com/cqlplatform/controller/FhirController.java
@@ -56,8 +56,31 @@ public class FhirController {
         return ResponseEntity.ok(igService.getProfiles(resourceType, search));
     }
 
+    // PAT-119: Tomcat's default URI parser rejects `%2F` inside path segments
+    // (StrictSecurity: block path-traversal), so the old `/ig/profiles/{url}` path
+    // variant 400'd on every real IG URL (all canonical URLs contain slashes).
+    // The new endpoint takes the canonical URL as a query param where encoded
+    // slashes are permitted.
+    @GetMapping("/ig/profiles/detail")
+    @Operation(summary = "Get IG Profile", description = "Get a StructureDefinition by canonical URL (query param)")
+    public ResponseEntity<String> getIgProfileDetail(@RequestParam("url") String url) {
+        if (igService == null || !igService.isLoaded()) {
+            return ResponseEntity.notFound().build();
+        }
+        InputValidator.requireValidFhirCanonicalUrl(url);
+        StructureDefinition sd = igService.getProfileByUrl(url);
+        if (sd == null) {
+            return ResponseEntity.notFound().build();
+        }
+        String json = fhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(sd);
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(json);
+    }
+
     @GetMapping("/ig/profiles/{url}")
-    @Operation(summary = "Get IG Profile", description = "Get a StructureDefinition by URL")
+    @Operation(summary = "(Deprecated) Get IG Profile by path URL",
+            description = "Kept for backwards compatibility; prefer /ig/profiles/detail?url=")
     public ResponseEntity<String> getIgProfile(@PathVariable String url) {
         if (igService == null || !igService.isLoaded()) {
             return ResponseEntity.notFound().build();
@@ -83,8 +106,26 @@ public class FhirController {
         return ResponseEntity.ok(igService.getValueSets(search));
     }
 
+    @GetMapping("/ig/valuesets/detail")
+    @Operation(summary = "Get IG ValueSet", description = "Get a ValueSet by canonical URL (query param) — PAT-119")
+    public ResponseEntity<String> getIgValueSetDetail(@RequestParam("url") String url) {
+        if (igService == null || !igService.isLoaded()) {
+            return ResponseEntity.notFound().build();
+        }
+        InputValidator.requireValidFhirCanonicalUrl(url);
+        ValueSet vs = igService.getValueSetByUrl(url);
+        if (vs == null) {
+            return ResponseEntity.notFound().build();
+        }
+        String json = fhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(vs);
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(json);
+    }
+
     @GetMapping("/ig/valuesets/{url}")
-    @Operation(summary = "Get IG ValueSet", description = "Get a ValueSet by URL with expansion")
+    @Operation(summary = "(Deprecated) Get IG ValueSet by path URL",
+            description = "Kept for backwards compatibility; prefer /ig/valuesets/detail?url=")
     public ResponseEntity<String> getIgValueSet(@PathVariable String url) {
         if (igService == null || !igService.isLoaded()) {
             return ResponseEntity.notFound().build();
@@ -110,8 +151,26 @@ public class FhirController {
         return ResponseEntity.ok(igService.getCodeSystems(search));
     }
 
+    @GetMapping("/ig/codesystems/detail")
+    @Operation(summary = "Get IG CodeSystem", description = "Get a CodeSystem by canonical URL (query param) — PAT-119")
+    public ResponseEntity<String> getIgCodeSystemDetail(@RequestParam("url") String url) {
+        if (igService == null || !igService.isLoaded()) {
+            return ResponseEntity.notFound().build();
+        }
+        InputValidator.requireValidFhirCanonicalUrl(url);
+        CodeSystem cs = igService.getCodeSystemByUrl(url);
+        if (cs == null) {
+            return ResponseEntity.notFound().build();
+        }
+        String json = fhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(cs);
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(json);
+    }
+
     @GetMapping("/ig/codesystems/{url}")
-    @Operation(summary = "Get IG CodeSystem", description = "Get a CodeSystem by URL")
+    @Operation(summary = "(Deprecated) Get IG CodeSystem by path URL",
+            description = "Kept for backwards compatibility; prefer /ig/codesystems/detail?url=")
     public ResponseEntity<String> getIgCodeSystem(@PathVariable String url) {
         if (igService == null || !igService.isLoaded()) {
             return ResponseEntity.notFound().build();

--- a/backend/src/main/java/com/cqlplatform/service/fhir/FhirImplementationGuideService.java
+++ b/backend/src/main/java/com/cqlplatform/service/fhir/FhirImplementationGuideService.java
@@ -138,7 +138,8 @@ public class FhirImplementationGuideService {
                         vs.getName(),
                         vs.getTitle(),
                         vs.getStatus() != null ? vs.getStatus().toCode() : null,
-                        countValueSetConcepts(vs)
+                        countValueSetConcepts(vs),
+                        hasComposeRules(vs)
                 ))
                 .collect(Collectors.toList());
     }
@@ -222,6 +223,23 @@ public class FhirImplementationGuideService {
         return 0;
     }
 
+    /**
+     * PAT-119: many TWCORE ValueSets use {@code compose.include.filter} (e.g.
+     * "all SNOMED CT descendants of X") or {@code compose.include.valueSet}
+     * (reference another VS) instead of inline {@code concept} lists. Previously
+     * the UI just showed "0 concepts" which read as "empty / broken"; callers
+     * now use this flag to render a hint that the VS needs terminology-server
+     * expansion to enumerate actual codes.
+     */
+    private boolean hasComposeRules(ValueSet vs) {
+        if (!vs.hasCompose()) return false;
+        for (ValueSet.ConceptSetComponent include : vs.getCompose().getInclude()) {
+            if (include.hasFilter() && !include.getFilter().isEmpty()) return true;
+            if (include.hasValueSet() && !include.getValueSet().isEmpty()) return true;
+        }
+        return false;
+    }
+
     // DTOs
     public record PackageMetadata(
             String name,
@@ -248,7 +266,11 @@ public class FhirImplementationGuideService {
             String name,
             String title,
             String status,
-            int conceptCount
+            int conceptCount,
+            /** PAT-119: true when the ValueSet uses compose.include.filter or
+             *  compose.include.valueSet (needs terminology-server expansion to
+             *  enumerate). Frontend renders a hint chip instead of "0". */
+            boolean hasComposeRules
     ) {}
 
     public record CodeSystemSummary(

--- a/frontend/src/api/fhirApi.ts
+++ b/frontend/src/api/fhirApi.ts
@@ -152,7 +152,8 @@ export const fhirApi = {
   },
 
   getProfile: async (url: string): Promise<unknown> => {
-    const response = await api.get(`/fhir/ig/profiles/${encodeURIComponent(url)}`)
+    // PAT-119: use query-param form; Tomcat rejects encoded slashes in path.
+    const response = await api.get(`/fhir/ig/profiles/detail`, { params: { url } })
     return response.data
   },
 
@@ -163,7 +164,8 @@ export const fhirApi = {
   },
 
   getIgValueSet: async (url: string): Promise<unknown> => {
-    const response = await api.get(`/fhir/ig/valuesets/${encodeURIComponent(url)}`)
+    // PAT-119: use query-param form; Tomcat rejects encoded slashes in path.
+    const response = await api.get(`/fhir/ig/valuesets/detail`, { params: { url } })
     return response.data
   },
 
@@ -174,7 +176,8 @@ export const fhirApi = {
   },
 
   getIgCodeSystem: async (url: string): Promise<unknown> => {
-    const response = await api.get(`/fhir/ig/codesystems/${encodeURIComponent(url)}`)
+    // PAT-119: use query-param form; Tomcat rejects encoded slashes in path.
+    const response = await api.get(`/fhir/ig/codesystems/detail`, { params: { url } })
     return response.data
   },
 

--- a/frontend/src/components/fhir/ImplementationGuideBrowser.tsx
+++ b/frontend/src/components/fhir/ImplementationGuideBrowser.tsx
@@ -324,7 +324,22 @@ function ValueSetsTab() {
                       <StatusChip status={vs.status || 'draft'} />
                     </TableCell>
                     <TableCell>
-                      <Chip label={vs.conceptCount} size="small" sx={{ bgcolor: (theme) => alpha(theme.palette.primary.main, 0.1), color: 'primary.dark', fontWeight: 600 }} />
+                      {vs.conceptCount > 0 ? (
+                        <Chip label={vs.conceptCount} size="small" sx={{ bgcolor: (theme) => alpha(theme.palette.primary.main, 0.1), color: 'primary.dark', fontWeight: 600 }} />
+                      ) : vs.hasComposeRules ? (
+                        // PAT-119: VS uses compose.include.filter or compose.include.valueSet
+                        // (e.g. "all SNOMED CT descendants of X"); no inline concepts to count.
+                        // Previously rendered as "0", which read as "empty / broken".
+                        <Chip
+                          label={t('ig.needsExpansion')}
+                          size="small"
+                          variant="outlined"
+                          sx={{ fontSize: '0.7rem', fontStyle: 'italic' }}
+                          title={t('ig.needsExpansionTooltip')}
+                        />
+                      ) : (
+                        <Chip label={0} size="small" sx={{ bgcolor: (theme) => alpha(theme.palette.primary.main, 0.1), color: 'primary.dark', fontWeight: 600 }} />
+                      )}
                     </TableCell>
                   </TableRow>
                 ))}

--- a/frontend/src/locales/en/fhir.json
+++ b/frontend/src/locales/en/fhir.json
@@ -185,6 +185,8 @@
     "valueSetCount_one": "{{count}} ValueSet",
     "valueSetLoadError": "Failed to load ValueSets: {{error}}",
     "noValueSets": "No ValueSets found.",
+    "needsExpansion": "Needs expansion",
+    "needsExpansionTooltip": "This ValueSet uses compose rules (filters or referenced ValueSets) and needs terminology-server expansion to enumerate concrete codes.",
     "searchCodeSystems": "Search CodeSystems",
     "searchCodeSystemsPlaceholder": "e.g., LOINC, SNOMED",
     "codeSystemCount": "{{count}} CodeSystems",

--- a/frontend/src/locales/zh-TW/fhir.json
+++ b/frontend/src/locales/zh-TW/fhir.json
@@ -185,6 +185,8 @@
     "valueSetCount_one": "{{count}} 個值集",
     "valueSetLoadError": "無法載入值集：{{error}}",
     "noValueSets": "未找到值集。",
+    "needsExpansion": "需展開",
+    "needsExpansionTooltip": "此值集使用 compose 規則（filter 或引用其他值集），需由術語伺服器展開才能列出具體代碼。",
     "searchCodeSystems": "搜尋代碼系統",
     "searchCodeSystemsPlaceholder": "例如：LOINC, SNOMED",
     "codeSystemCount": "{{count}} 個代碼系統",

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -965,6 +965,11 @@ export interface ValueSetSummary {
   title: string
   status: string
   conceptCount: number
+  /** PAT-119: true when the ValueSet uses compose.include.filter or
+   *  compose.include.valueSet (e.g. "all SNOMED CT descendants of X"),
+   *  so it needs terminology-server $expand to enumerate actual codes.
+   *  Frontend should render a hint chip instead of "0 concepts". */
+  hasComposeRules?: boolean
 }
 
 export interface CodeSystemSummary {


### PR DESCRIPTION
## 使用者回報

FHIR 瀏覽器裡 TWCORE IG 的設定檔無法載入。

## Root cause（我們的 bug，不是 TWCORE）

IG package 載入 OK（99 profiles / 55 valuesets / 30 codesystems），列表 API 全正常。但點進任一資源看 detail 都 400。

FE 呼叫：
```
GET /api/fhir/ig/profiles/https%3A%2F%2Ftwcore.mohw.gov.tw%2Fig%2Ftwcore%2FStructureDefinition%2FAddress-tw
```

Tomcat 預設 security 擋 `%2F` 在 path segment 裡（防 path traversal）→ 400 HTML、Spring 沒被呼叫。所有 3 個 detail endpoints（profiles/valuesets/codesystems）都一樣。

## 主修：改用 query param

- 新 `/api/fhir/ig/profiles/detail?url=...` + `/valuesets/detail` + `/codesystems/detail`
- Query param 值接受 %2F
- 舊 `{url}` path endpoint 保留為 deprecated 兼容層
- FE 3 個 method 改用 axios `params: { url }`

## 次修：ValueSet conceptCount 顯示

TWCORE 很多 ValueSet 採 `compose.include.filter`（如「SNOMED CT 某 code 後代」）或 `compose.include.valueSet` 而非 inline concepts。我們原本只算 inline concepts、顯示「0」讓使用者誤判「空」。

- 後端 `ValueSetSummary` 加 `hasComposeRules` flag
- 前端顯示「需展開 / Needs expansion」chip（替代 "0"）+ hover tooltip
- zh-TW / en i18n 同步

## 風險

- 新 endpoint 與舊並存、向後相容
- 舊 path-variable endpoint 仍可用（若 url 不含 slashes 仍會 work，雖然實務上所有 FHIR canonical URL 都有）
- 次修純 UI 增強、不改行為
- 無 DB migration、無 API breaking change

## 測試

- Backend `FhirControllerTest` 25/25 + `FhirImplementationGuideServiceTest` 7/7 pass
- `tsc --noEmit` 零 error
- 手動驗收（部署後）：
  1. IG Browser → Profiles tab → 點 Address-tw → 彈出詳細 JSON
  2. ValueSets tab → 找 `category-code-tw` → Concepts 欄位顯示「需展開」而非 0

## TFDA

| 需求 |
|------|
| #402 |

安全性等級：**A**（純 URL 編碼 / UX bug，不涉 patient safety）

🤖 Generated with [Claude Code](https://claude.com/claude-code)