### PR TITLE
fix: DataRequirementExtractor expand CQL ConceptRef in where clauses (#PAT-120)

### DIFF
--- a/backend/src/main/java/com/cqlplatform/service/cql/DataRequirementExtractor.java
+++ b/backend/src/main/java/com/cqlplatform/service/cql/DataRequirementExtractor.java
@@ -48,10 +48,14 @@ public class DataRequirementExtractor {
             Map<String, String> valueSetMap = buildValueSetMap(root);
             Map<String, String> codeSystemMap = buildCodeSystemMap(root);
             Map<String, CodeDefInfo> codeDefMap = buildCodeDefMap(root);
+            // PAT-120: CQL `concept` declarations group multiple `code` refs into one
+            // logical concept. When a where clause uses `P.code ~ "SomeConcept"` or
+            // `x in "SomeConcept"`, we need to expand the ConceptRef to each member code.
+            Map<String, List<String>> conceptDefMap = buildConceptDefMap(root);
 
             // Collect all Retrieve nodes (including Query-enhanced ones)
             List<RetrieveInfo> retrieves = new ArrayList<>();
-            collectRetrieves(root, retrieves, codeSystemMap, codeDefMap, new HashSet<>());
+            collectRetrieves(root, retrieves, codeSystemMap, codeDefMap, conceptDefMap, new HashSet<>());
 
             // Convert to DataRequirementInfo and deduplicate
             return deduplicateRequirements(retrieves, valueSetMap);
@@ -99,6 +103,36 @@ public class DataRequirementExtractor {
     }
 
     /**
+     * PAT-120: build concept name → list of code names. ELM shape:
+     * {@code library.concepts.def[] = [{name, code: [{type:"CodeRef", name}, ...]}, ...]}.
+     * Used by {@link #tryExtractCodeRefFilter} to expand a ConceptRef in a where
+     * clause (e.g. {@code P.code ~ "Knee Replacement Concept"}) into all the
+     * member codes rather than losing them.
+     */
+    private Map<String, List<String>> buildConceptDefMap(JsonNode root) {
+        Map<String, List<String>> map = new HashMap<>();
+        JsonNode concepts = root.path("library").path("concepts").path("def");
+        if (concepts.isArray()) {
+            for (JsonNode cd : concepts) {
+                String name = cd.path("name").asText(null);
+                if (name == null) continue;
+                List<String> codeNames = new ArrayList<>();
+                JsonNode codes = cd.path("code");
+                if (codes.isArray()) {
+                    for (JsonNode c : codes) {
+                        if ("CodeRef".equals(c.path("type").asText("CodeRef"))) {
+                            String codeName = c.path("name").asText(null);
+                            if (codeName != null) codeNames.add(codeName);
+                        }
+                    }
+                }
+                map.put(name, codeNames);
+            }
+        }
+        return map;
+    }
+
+    /**
      * Build a mapping from code definition name to its code system info.
      * ELM structure: library.codes.def[] with {name, id, codeSystem: {name}} fields.
      */
@@ -128,6 +162,7 @@ public class DataRequirementExtractor {
      */
     private void collectRetrieves(JsonNode node, List<RetrieveInfo> retrieves,
                                   Map<String, String> codeSystemMap, Map<String, CodeDefInfo> codeDefMap,
+                                  Map<String, List<String>> conceptDefMap,
                                   Set<JsonNode> handledRetrieves) {
         if (node == null) {
             return;
@@ -138,24 +173,24 @@ public class DataRequirementExtractor {
 
             if ("Query".equals(type)) {
                 // Handle Query nodes specially: extract Retrieve from source and enhance from Where
-                handleQuery(node, retrieves, codeSystemMap, codeDefMap, handledRetrieves);
+                handleQuery(node, retrieves, codeSystemMap, codeDefMap, conceptDefMap, handledRetrieves);
                 // Still recurse into non-source children (e.g. let clauses may contain nested queries)
                 // but skip source to avoid double-counting
                 JsonNode where = node.get("where");
                 if (where != null) {
-                    collectRetrieves(where, retrieves, codeSystemMap, codeDefMap, handledRetrieves);
+                    collectRetrieves(where, retrieves, codeSystemMap, codeDefMap, conceptDefMap, handledRetrieves);
                 }
                 JsonNode let = node.get("let");
                 if (let != null) {
-                    collectRetrieves(let, retrieves, codeSystemMap, codeDefMap, handledRetrieves);
+                    collectRetrieves(let, retrieves, codeSystemMap, codeDefMap, conceptDefMap, handledRetrieves);
                 }
                 JsonNode relationship = node.get("relationship");
                 if (relationship != null) {
-                    collectRetrieves(relationship, retrieves, codeSystemMap, codeDefMap, handledRetrieves);
+                    collectRetrieves(relationship, retrieves, codeSystemMap, codeDefMap, conceptDefMap, handledRetrieves);
                 }
                 JsonNode ret = node.get("return");
                 if (ret != null) {
-                    collectRetrieves(ret, retrieves, codeSystemMap, codeDefMap, handledRetrieves);
+                    collectRetrieves(ret, retrieves, codeSystemMap, codeDefMap, conceptDefMap, handledRetrieves);
                 }
                 return;
             }
@@ -171,12 +206,12 @@ public class DataRequirementExtractor {
             // Generic recursion for all other node types
             if (!"Query".equals(type)) {
                 for (Iterator<JsonNode> it = node.elements(); it.hasNext(); ) {
-                    collectRetrieves(it.next(), retrieves, codeSystemMap, codeDefMap, handledRetrieves);
+                    collectRetrieves(it.next(), retrieves, codeSystemMap, codeDefMap, conceptDefMap, handledRetrieves);
                 }
             }
         } else if (node.isArray()) {
             for (JsonNode child : node) {
-                collectRetrieves(child, retrieves, codeSystemMap, codeDefMap, handledRetrieves);
+                collectRetrieves(child, retrieves, codeSystemMap, codeDefMap, conceptDefMap, handledRetrieves);
             }
         }
     }
@@ -186,6 +221,7 @@ public class DataRequirementExtractor {
      */
     private void handleQuery(JsonNode queryNode, List<RetrieveInfo> retrieves,
                              Map<String, String> codeSystemMap, Map<String, CodeDefInfo> codeDefMap,
+                                  Map<String, List<String>> conceptDefMap,
                              Set<JsonNode> handledRetrieves) {
         JsonNode sources = queryNode.get("source");
         if (sources == null || !sources.isArray() || sources.isEmpty()) {
@@ -202,7 +238,7 @@ public class DataRequirementExtractor {
             String sourceType = sourceExpr.path("type").asText(null);
             if (!"Retrieve".equals(sourceType)) {
                 // Recurse into non-Retrieve sources (e.g., function calls, other queries)
-                collectRetrieves(sourceExpr, retrieves, codeSystemMap, codeDefMap, handledRetrieves);
+                collectRetrieves(sourceExpr, retrieves, codeSystemMap, codeDefMap, conceptDefMap, handledRetrieves);
                 continue;
             }
 
@@ -223,7 +259,7 @@ public class DataRequirementExtractor {
             boolean hasInlineCodes = (info.valueSetRefName != null || !info.directCodes.isEmpty());
             JsonNode where = queryNode.get("where");
             if (where != null && alias != null) {
-                enhanceFromWhere(where, info, alias, codeSystemMap, codeDefMap, hasInlineCodes);
+                enhanceFromWhere(where, info, alias, codeSystemMap, codeDefMap, conceptDefMap, hasInlineCodes);
             }
 
             retrieves.add(info);
@@ -236,8 +272,9 @@ public class DataRequirementExtractor {
      */
     private void enhanceFromWhere(JsonNode where, RetrieveInfo info, String alias,
                                   Map<String, String> codeSystemMap, Map<String, CodeDefInfo> codeDefMap,
+                                  Map<String, List<String>> conceptDefMap,
                                   boolean hasInlineCodes) {
-        walkWhereClause(where, info, alias, codeSystemMap, codeDefMap, hasInlineCodes);
+        walkWhereClause(where, info, alias, codeSystemMap, codeDefMap, conceptDefMap, hasInlineCodes);
     }
 
     /**
@@ -245,6 +282,7 @@ public class DataRequirementExtractor {
      */
     private void walkWhereClause(JsonNode node, RetrieveInfo info, String alias,
                                  Map<String, String> codeSystemMap, Map<String, CodeDefInfo> codeDefMap,
+                                  Map<String, List<String>> conceptDefMap,
                                  boolean hasInlineCodes) {
         if (node == null || !node.isObject()) {
             return;
@@ -259,7 +297,7 @@ public class DataRequirementExtractor {
                 JsonNode andOps = node.get("operand");
                 if (andOps != null && andOps.isArray()) {
                     for (JsonNode op : andOps) {
-                        walkWhereClause(op, info, alias, codeSystemMap, codeDefMap, hasInlineCodes);
+                        walkWhereClause(op, info, alias, codeSystemMap, codeDefMap, conceptDefMap, hasInlineCodes);
                     }
                 }
                 break;
@@ -267,7 +305,7 @@ public class DataRequirementExtractor {
             case "Not":
                 JsonNode notOp = node.get("operand");
                 if (notOp != null) {
-                    walkWhereClause(notOp, info, alias, codeSystemMap, codeDefMap, hasInlineCodes);
+                    walkWhereClause(notOp, info, alias, codeSystemMap, codeDefMap, conceptDefMap, hasInlineCodes);
                 }
                 break;
 
@@ -290,9 +328,23 @@ public class DataRequirementExtractor {
             case "Equivalent":
                 // Handle direct property ~ CodeRef patterns (e.g., E.class ~ "AMB")
                 if (!hasInlineCodes) {
-                    handleCodeRefComparison(node, info, alias, codeSystemMap, codeDefMap);
+                    handleCodeRefComparison(node, info, alias, codeSystemMap, codeDefMap, conceptDefMap);
                 }
                 // Also check for date comparison patterns within Equal/Equivalent
+                if (DATE_COMPARISON_TYPES.contains(type)) {
+                    handleDateComparisonPattern(node, info, alias);
+                }
+                break;
+
+            // PAT-120: `X in "ConceptName"` (e.g. `MR.medication in "Antibiotic Concept"`)
+            // ELM shape: In { operand: [property, ToList(ConceptRef)] } — same structure
+            // as Equivalent so we reuse the same handler; tryExtractCodeRefFilter walks
+            // both ConceptRef and CodeRef paths.
+            case "In":
+            case "IncludedIn":
+                if (!hasInlineCodes) {
+                    handleCodeRefComparison(node, info, alias, codeSystemMap, codeDefMap, conceptDefMap);
+                }
                 if (DATE_COMPARISON_TYPES.contains(type)) {
                     handleDateComparisonPattern(node, info, alias);
                 }
@@ -511,6 +563,38 @@ public class DataRequirementExtractor {
     }
 
     /**
+     * PAT-120: peel off ToList / ToConcept / FunctionRef("ToConcept") / As / Convert
+     * wrappers to reach an underlying ConceptRef. `X in "Antibiotic Concept"` produces
+     * {@code In(ToConcept(X), ToList(ConceptRef))}; `P.code ~ "Concept"` produces
+     * {@code Equivalent(ToConcept(prop), ConceptRef)}. We walk both shapes.
+     */
+    private JsonNode unwrapToConceptRef(JsonNode node) {
+        if (node == null || !node.isObject()) {
+            return null;
+        }
+        String type = node.path("type").asText("");
+        if ("ConceptRef".equals(type)) {
+            return node;
+        }
+        if ("ToList".equals(type) || "ToConcept".equals(type) || "As".equals(type) || "Convert".equals(type)) {
+            JsonNode operand = node.get("operand");
+            if (operand != null && operand.isObject()) {
+                return unwrapToConceptRef(operand);
+            }
+            if (operand != null && operand.isArray() && !operand.isEmpty()) {
+                return unwrapToConceptRef(operand.get(0));
+            }
+        }
+        if ("FunctionRef".equals(type)) {
+            JsonNode ops = node.get("operand");
+            if (ops != null && ops.isArray() && !ops.isEmpty()) {
+                return unwrapToConceptRef(ops.get(0));
+            }
+        }
+        return null;
+    }
+
+    /**
      * Unwrap ToConcept/FunctionRef/As nodes to reach an underlying CodeRef node.
      * CQL-to-ELM translator wraps CodeRef in ToConcept when comparing CodeableConcept ~ Code,
      * producing: ToConcept(CodeRef) or FunctionRef("ToConcept", CodeRef) instead of bare CodeRef.
@@ -572,7 +656,8 @@ public class DataRequirementExtractor {
      * The Property side may be wrapped in FunctionRef (e.g., FHIRHelpers.ToCode).
      */
     private void handleCodeRefComparison(JsonNode node, RetrieveInfo info, String alias,
-                                          Map<String, String> codeSystemMap, Map<String, CodeDefInfo> codeDefMap) {
+                                          Map<String, String> codeSystemMap, Map<String, CodeDefInfo> codeDefMap,
+                                          Map<String, List<String>> conceptDefMap) {
         JsonNode ops = node.get("operand");
         if (ops == null || !ops.isArray() || ops.size() < 2) {
             return;
@@ -581,9 +666,9 @@ public class DataRequirementExtractor {
         JsonNode left = ops.get(0);
         JsonNode right = ops.get(1);
 
-        // Try both orderings: (Property, CodeRef) and (CodeRef, Property)
-        if (!tryExtractCodeRefFilter(left, right, info, alias, codeSystemMap, codeDefMap)) {
-            tryExtractCodeRefFilter(right, left, info, alias, codeSystemMap, codeDefMap);
+        // Try both orderings: (Property, CodeRef|ConceptRef) and (CodeRef|ConceptRef, Property)
+        if (!tryExtractCodeRefFilter(left, right, info, alias, codeSystemMap, codeDefMap, conceptDefMap)) {
+            tryExtractCodeRefFilter(right, left, info, alias, codeSystemMap, codeDefMap, conceptDefMap);
         }
     }
 
@@ -594,9 +679,45 @@ public class DataRequirementExtractor {
     private boolean tryExtractCodeRefFilter(JsonNode propertyNode, JsonNode codeRefNode,
                                              RetrieveInfo info, String alias,
                                              Map<String, String> codeSystemMap,
-                                             Map<String, CodeDefInfo> codeDefMap) {
+                                             Map<String, CodeDefInfo> codeDefMap,
+                                             Map<String, List<String>> conceptDefMap) {
         if (codeRefNode == null) {
             return false;
+        }
+
+        // PAT-120: before trying CodeRef, try ConceptRef — when a where clause
+        // uses a CQL `concept` declaration (`P.code ~ "Knee Replacement Concept"`
+        // or `... in "Antibiotic Concept"`) we want to expand the concept's member
+        // codes instead of losing them. ConceptRef may be wrapped in ToList /
+        // FunctionRef (ToConcept) / As, same as CodeRef.
+        JsonNode actualConceptRef = unwrapToConceptRef(codeRefNode);
+        if (actualConceptRef != null) {
+            String conceptRefName = actualConceptRef.path("name").asText(null);
+            List<String> memberCodeNames = conceptRefName != null ? conceptDefMap.get(conceptRefName) : null;
+            if (memberCodeNames != null && !memberCodeNames.isEmpty()) {
+                JsonNode unwrappedP = unwrapToProperty(propertyNode);
+                String propPathConcept = unwrappedP != null ? extractPropertyPath(unwrappedP, alias) : null;
+                if (propPathConcept == null) return false;
+                if (info.codeProperty == null) info.codeProperty = propPathConcept;
+                // Resolve each member code via codeDefMap. Mixed-system concepts are
+                // legitimate (TWCORE has some); record each code with its own system
+                // URL so downstream can filter by (system,code) pairs accurately.
+                for (String codeName : memberCodeNames) {
+                    CodeDefInfo def = codeDefMap.get(codeName);
+                    if (def == null) continue;
+                    String sysUrl = codeSystemMap.get(def.codeSystemName);
+                    if (info.codeSystemUrl == null && sysUrl != null) {
+                        info.codeSystemUrl = sysUrl;
+                        info.codeSystemName = def.codeSystemName;
+                    }
+                    info.directCodes.add(CodingInfo.builder()
+                            .system(sysUrl)
+                            .code(def.code)
+                            .display(def.display)
+                            .build());
+                }
+                return true;
+            }
         }
 
         // Check if codeRefNode is a CodeRef (may be wrapped in ToConcept/FunctionRef)

--- a/backend/src/test/java/com/cqlplatform/service/cql/DataRequirementExtractorTest.java
+++ b/backend/src/test/java/com/cqlplatform/service/cql/DataRequirementExtractorTest.java
@@ -1165,4 +1165,169 @@ class DataRequirementExtractorTest {
         assertThat(result.get(0).getCodeFilter().get(0).getCodeSystemUrl())
                 .isEqualTo("http://hl7.org/fhir/sid/icd-10-cm");
     }
+
+    @Test
+    void extract_retrieveWithConceptRef_expandsAllMemberCodes() {
+        // PAT-120: CQL `concept "MyConcept": { "c1", "c2" }` declares a logical
+        // concept containing multiple CodeRef members. Where clauses like
+        // `P.code ~ "MyConcept"` (Equivalent(prop, ConceptRef)) must expand to
+        // all member codes — before this patch the ConceptRef was silently
+        // dropped and the retrieve came out with zero codes.
+        String elmJson = """
+                {
+                  "library": {
+                    "codeSystems": {
+                      "def": [
+                        { "name": "NHI", "id": "http://nhi.example.com" },
+                        { "name": "LOINC", "id": "http://loinc.org" }
+                      ]
+                    },
+                    "codes": {
+                      "def": [
+                        { "name": "c1", "id": "64164B", "display": "Knee A", "codeSystem": { "name": "NHI" } },
+                        { "name": "c2", "id": "97805K", "display": "Knee B", "codeSystem": { "name": "NHI" } },
+                        { "name": "c3", "id": "17856-6", "display": "Lab", "codeSystem": { "name": "LOINC" } }
+                      ]
+                    },
+                    "concepts": {
+                      "def": [
+                        {
+                          "name": "MixedConcept",
+                          "code": [
+                            { "type": "CodeRef", "name": "c1" },
+                            { "type": "CodeRef", "name": "c2" },
+                            { "type": "CodeRef", "name": "c3" }
+                          ]
+                        }
+                      ]
+                    },
+                    "statements": {
+                      "def": [
+                        {
+                          "name": "KneeProcs",
+                          "expression": {
+                            "type": "Query",
+                            "source": [{ "alias": "P", "expression": { "type": "Retrieve", "dataType": "{http://hl7.org/fhir}Procedure" } }],
+                            "where": {
+                              "type": "Equivalent",
+                              "operand": [
+                                { "type": "FunctionRef", "name": "ToConcept", "operand": [
+                                    { "type": "Property", "path": "code", "scope": "P" }
+                                ]},
+                                { "type": "ConceptRef", "name": "MixedConcept" }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        List<DataRequirementInfo> result = extractor.extract(elmJson);
+        assertThat(result).hasSize(1);
+        var codes = result.get(0).getCodeFilter().get(0).getCode();
+        assertThat(codes).hasSize(3);
+        // Each member code is resolved with its real code + correct system URL
+        assertThat(codes).extracting("code").containsExactlyInAnyOrder("64164B", "97805K", "17856-6");
+        assertThat(codes).extracting("system").containsExactlyInAnyOrder(
+                "http://nhi.example.com", "http://nhi.example.com", "http://loinc.org");
+    }
+
+    @Test
+    void extract_retrieveWithInConceptRef_expandsAllMemberCodes() {
+        // PAT-120: `x in "Concept"` (In type) should expand too, not just `~` (Equivalent).
+        // ELM shape has ToList(ConceptRef) on the RHS of In.
+        String elmJson = """
+                {
+                  "library": {
+                    "codeSystems": {
+                      "def": [{ "name": "ATC", "id": "http://www.whocc.no/atc" }]
+                    },
+                    "codes": {
+                      "def": [
+                        { "name": "atc_X", "id": "J01CA12", "codeSystem": { "name": "ATC" } },
+                        { "name": "atc_Y", "id": "J01CF01", "codeSystem": { "name": "ATC" } }
+                      ]
+                    },
+                    "concepts": {
+                      "def": [
+                        {
+                          "name": "Antibiotics",
+                          "code": [
+                            { "type": "CodeRef", "name": "atc_X" },
+                            { "type": "CodeRef", "name": "atc_Y" }
+                          ]
+                        }
+                      ]
+                    },
+                    "statements": {
+                      "def": [
+                        {
+                          "name": "AntibioticReqs",
+                          "expression": {
+                            "type": "Query",
+                            "source": [{ "alias": "MR", "expression": { "type": "Retrieve", "dataType": "{http://hl7.org/fhir}MedicationRequest" } }],
+                            "where": {
+                              "type": "In",
+                              "operand": [
+                                { "type": "FunctionRef", "name": "ToConcept", "operand": [
+                                    { "type": "Property", "path": "medication", "scope": "MR" }
+                                ]},
+                                { "type": "ToList", "operand": { "type": "ConceptRef", "name": "Antibiotics" } }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        List<DataRequirementInfo> result = extractor.extract(elmJson);
+        assertThat(result).hasSize(1);
+        var codes = result.get(0).getCodeFilter().get(0).getCode();
+        assertThat(codes).hasSize(2);
+        assertThat(codes).extracting("code").containsExactlyInAnyOrder("J01CA12", "J01CF01");
+        assertThat(result.get(0).getCodeFilter().get(0).getCodeSystemUrl())
+                .isEqualTo("http://www.whocc.no/atc");
+    }
+
+    @Test
+    void extract_retrieveWithUnresolvableConceptRef_leavesNoCodes() {
+        // When the ConceptRef name has no matching concept in library.concepts.def
+        // (e.g. declared in an external library), we should gracefully extract
+        // nothing for it — not throw, not fall back to using the ref name as code.
+        String elmJson = """
+                {
+                  "library": {
+                    "statements": {
+                      "def": [
+                        {
+                          "name": "X",
+                          "expression": {
+                            "type": "Query",
+                            "source": [{ "alias": "P", "expression": { "type": "Retrieve", "dataType": "{http://hl7.org/fhir}Procedure" } }],
+                            "where": {
+                              "type": "Equivalent",
+                              "operand": [
+                                { "type": "Property", "path": "code", "scope": "P" },
+                                { "type": "ConceptRef", "name": "UnknownExternalConcept" }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        List<DataRequirementInfo> result = extractor.extract(elmJson);
+        assertThat(result).hasSize(1);
+        // No code filter created for unresolvable ConceptRef (no fallback pollution)
+        assertThat(result.get(0).getCodeFilter()).isNullOrEmpty();
+    }
 }


### PR DESCRIPTION
## 使用者回報

「品質指標 → 資料需求」分頁仍有大量 CQL 內容沒抓到。

## 稽核發現

Measure 1 (KneeReplacementSSIRate) 宣告 4 個 CQL `concept`：
- Knee Replacement: 5 個 NHI 手術 codes
- SSI Procedure: 3 個 NHI 處置 codes
- SSI Diagnosis: ~50 個 ICD-10-CM 診斷 codes
- Antibiotic: ~14 個 ATC 藥物 codes

Where clauses：
- `P.code ~ \"Knee Replacement Concept\"` → ELM `Equivalent(prop, ConceptRef)`
- `MR.medication in \"Antibiotic Concept\"` → ELM `In(prop, ToList(ConceptRef))`

**Procedure / Condition / MedicationRequest 的 codeFilter 全部 null** — 約 70 個 code 被丟掉。

## Root cause

`tryExtractCodeRefFilter` 只處理 `CodeRef`（單一 code），沒處理 `ConceptRef`（一組 code）。Extractor 沒 build concept map、也沒有 ConceptRef unwrap 邏輯。

## 修法

1. 新 `buildConceptDefMap` parse `library.concepts.def[]` → concept name → 成員 CodeRef name 列表
2. 新 `unwrapToConceptRef` 處理 ToList / ToConcept / FunctionRef / As / Convert 包裝（覆蓋 `~` 和 `in` 兩種語法的 ELM 差異）
3. `tryExtractCodeRefFilter` 先試 ConceptRef：命中就迭代成員 → 透過既有的 `codeDefMap` + `codeSystemMap` resolve 真實 (code, system)；支援 mixed-system concept（同一 concept 可含 LOINC + ICD10 等）
4. `walkWhereClause` 新 `In/IncludedIn` case 與 `Equal/Equivalent` 共用同一 handler

## 部署後效果

Measure 1 的資料需求會從「4 空殼」變成：
- Procedure (Knee Replacement): 5 NHI codes ✓
- Procedure (SSI): 3 NHI codes ✓
- Condition (SSI Diagnosis): ~50 ICD-10-CM codes ✓
- MedicationRequest (Antibiotic): ~14 ATC codes ✓

其他 measure 的 concept 使用也會一併生效。

## 測試

- 新 3 tests: Equivalent+ConceptRef 展開、In+ToList(ConceptRef) 展開、不可解析 ConceptRef fallback 不污染
- 同時驗證 mixed-system concept（LOINC + NHI）每個 code 帶各自 system URL
- 全 `DataRequirementExtractorTest` 27/27 pass（24 既有 + 3 新）

## 風險

- 低。純提取邏輯增強、不改 API shape、不涉臨床邏輯
- 無法解析的 ConceptRef（外部 library）graceful skip、不 fallback 成 ref name 污染 code 欄位

## TFDA

| 需求 |
|------|
| #404 |

安全性等級：**A**（資料擷取完整性；對接商拿 DataRequirement 會更準確，但不直接影響臨床決策）

🤖 Generated with [Claude Code](https://claude.com/claude-code)