### PR TITLE
fix: data-requirements demographic + prefix + nested-exists system (#PAT-121)

### DIFF
--- a/backend/src/main/java/com/cqlplatform/model/measure/DataRequirementInfo.java
+++ b/backend/src/main/java/com/cqlplatform/model/measure/DataRequirementInfo.java
@@ -16,6 +16,9 @@ public class DataRequirementInfo {
     private List<String> profile;
     private List<CodeFilterInfo> codeFilter;
     private List<DateFilterInfo> dateFilter;
+    /** PAT-121a: only populated on the Patient entry — age/gender constraints
+     *  extracted from where clauses across all measure expressions. */
+    private PatientFilterInfo patientFilter;
 
     @Data
     @Builder
@@ -28,6 +31,26 @@ public class DataRequirementInfo {
         private String codeSystemUrl;
         private String codeSystemName;
         private List<CodingInfo> code;
+        /** PAT-121b: prefixes collected from {@code StartsWith(Coding.code.value, 'E08')}
+         *  patterns. Clinical CQL commonly groups ICD codes by prefix rather than
+         *  enumerating each — this field surfaces that intent so callers can either
+         *  translate to FHIR search (e.g. {@code code=E08*}) or display as a range. */
+        private List<String> codePrefixes;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PatientFilterInfo {
+        /** Minimum age (inclusive). Null if unconstrained. */
+        private Integer minAge;
+        /** Maximum age (inclusive). Null if unconstrained. */
+        private Integer maxAge;
+        /** {@code "Year"}, {@code "Month"}, etc. — precision the CQL's CalculateAge used. */
+        private String ageUnit;
+        /** Allowed gender values (from CQL {@code Patient.gender = 'male'} equality). */
+        private List<String> gender;
     }
 
     @Data

--- a/backend/src/main/java/com/cqlplatform/service/cql/DataRequirementExtractor.java
+++ b/backend/src/main/java/com/cqlplatform/service/cql/DataRequirementExtractor.java
@@ -4,6 +4,7 @@ import com.cqlplatform.model.measure.DataRequirementInfo;
 import com.cqlplatform.model.measure.DataRequirementInfo.CodeFilterInfo;
 import com.cqlplatform.model.measure.DataRequirementInfo.CodingInfo;
 import com.cqlplatform.model.measure.DataRequirementInfo.DateFilterInfo;
+import com.cqlplatform.model.measure.DataRequirementInfo.PatientFilterInfo;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -57,8 +58,14 @@ public class DataRequirementExtractor {
             List<RetrieveInfo> retrieves = new ArrayList<>();
             collectRetrieves(root, retrieves, codeSystemMap, codeDefMap, conceptDefMap, new HashSet<>());
 
+            // PAT-121a: scan the whole ELM once for Patient demographic filters
+            // (age / gender). They usually live in "Initial Population" or similar
+            // expressions, not inside a Patient retrieve — so we walk the entire
+            // tree separately rather than expecting per-retrieve where clauses.
+            PatientFilterInfo patientFilter = collectPatientFilter(root);
+
             // Convert to DataRequirementInfo and deduplicate
-            return deduplicateRequirements(retrieves, valueSetMap);
+            return deduplicateRequirements(retrieves, valueSetMap, patientFilter);
         } catch (Exception e) {
             log.warn("Failed to extract data requirements from ELM JSON: {}", e.getMessage());
             return Collections.emptyList();
@@ -130,6 +137,167 @@ public class DataRequirementExtractor {
             }
         }
         return map;
+    }
+
+    /**
+     * PAT-121a: walk all statement expressions collecting Patient demographic
+     * filters. CQL usually expresses these at measure-level (e.g. in an
+     * "Initial Population" define: {@code AgeInYearsAt(...) >= 18 and
+     * AgeInYearsAt(...) <= 64} and/or {@code Patient.gender = 'male'}), not
+     * inside individual Retrieve where clauses — so we scan the whole tree
+     * separately and aggregate the constraints.
+     *
+     * <p>Returns null when no demographic filters are detected so the emitted
+     * Patient entry stays minimal for measures that apply to all demographics.
+     */
+    private PatientFilterInfo collectPatientFilter(JsonNode root) {
+        PatientFilterInfo acc = new PatientFilterInfo();
+        acc.setGender(new ArrayList<>());
+        walkForPatientFilter(root, acc);
+        boolean hasAny = acc.getMinAge() != null || acc.getMaxAge() != null
+                || !acc.getGender().isEmpty();
+        if (!hasAny) return null;
+        if (acc.getGender().isEmpty()) acc.setGender(null);
+        return acc;
+    }
+
+    private void walkForPatientFilter(JsonNode node, PatientFilterInfo acc) {
+        if (node == null) return;
+        if (node.isObject()) {
+            String type = node.path("type").asText("");
+            if (!type.isEmpty()) {
+                tryMatchAgeFilter(node, type, acc);
+                tryMatchGenderFilter(node, type, acc);
+            }
+            for (Iterator<JsonNode> it = node.elements(); it.hasNext(); ) {
+                walkForPatientFilter(it.next(), acc);
+            }
+        } else if (node.isArray()) {
+            for (JsonNode child : node) walkForPatientFilter(child, acc);
+        }
+    }
+
+    /**
+     * PAT-121a: match {@code GreaterOrEqual/LessOrEqual/Greater/Less/Equal}
+     * where one operand is a {@code CalculateAge}/{@code CalculateAgeAt} call
+     * and the other is an integer Literal. Narrows min/max conservatively —
+     * {@code >= 18} tightens minAge to max(existing, 18).
+     */
+    private void tryMatchAgeFilter(JsonNode node, String type, PatientFilterInfo acc) {
+        boolean isComparison = "GreaterOrEqual".equals(type) || "LessOrEqual".equals(type)
+                || "Greater".equals(type) || "Less".equals(type) || "Equal".equals(type);
+        if (!isComparison) return;
+        JsonNode ops = node.get("operand");
+        if (ops == null || !ops.isArray() || ops.size() < 2) return;
+        JsonNode a = ops.get(0);
+        JsonNode b = ops.get(1);
+        // Detect which side is CalculateAge, which is Literal
+        Integer ageLiteral;
+        String precision;
+        boolean ageOnLeft;
+        if (isCalculateAgeCall(a) && isIntLiteral(b)) {
+            precision = a.path("precision").asText(null);
+            ageLiteral = parseIntLiteral(b);
+            ageOnLeft = true;
+        } else if (isCalculateAgeCall(b) && isIntLiteral(a)) {
+            precision = b.path("precision").asText(null);
+            ageLiteral = parseIntLiteral(a);
+            ageOnLeft = false;
+        } else {
+            return;
+        }
+        if (ageLiteral == null) return;
+        if (acc.getAgeUnit() == null && precision != null) acc.setAgeUnit(precision);
+
+        // Normalize so comparison reads "age <op> literal"
+        String effective = ageOnLeft ? type : flipComparison(type);
+        switch (effective) {
+            case "GreaterOrEqual": // age >= N → minAge = max(existing, N)
+                if (acc.getMinAge() == null || ageLiteral > acc.getMinAge()) acc.setMinAge(ageLiteral);
+                break;
+            case "Greater": // age > N → minAge = max(existing, N+1)
+                int inclusive = ageLiteral + 1;
+                if (acc.getMinAge() == null || inclusive > acc.getMinAge()) acc.setMinAge(inclusive);
+                break;
+            case "LessOrEqual":
+                if (acc.getMaxAge() == null || ageLiteral < acc.getMaxAge()) acc.setMaxAge(ageLiteral);
+                break;
+            case "Less":
+                int maxIncl = ageLiteral - 1;
+                if (acc.getMaxAge() == null || maxIncl < acc.getMaxAge()) acc.setMaxAge(maxIncl);
+                break;
+            case "Equal":
+                acc.setMinAge(ageLiteral);
+                acc.setMaxAge(ageLiteral);
+                break;
+            default: // no-op
+        }
+    }
+
+    private boolean isCalculateAgeCall(JsonNode node) {
+        if (node == null || !node.isObject()) return false;
+        String t = node.path("type").asText("");
+        return "CalculateAge".equals(t) || "CalculateAgeAt".equals(t);
+    }
+
+    private boolean isIntLiteral(JsonNode node) {
+        if (node == null || !node.isObject()) return false;
+        if (!"Literal".equals(node.path("type").asText(""))) return false;
+        String vt = node.path("valueType").asText("");
+        return vt.contains("Integer");
+    }
+
+    private Integer parseIntLiteral(JsonNode node) {
+        try {
+            return Integer.parseInt(node.path("value").asText(""));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private String flipComparison(String op) {
+        switch (op) {
+            case "GreaterOrEqual": return "LessOrEqual";
+            case "LessOrEqual": return "GreaterOrEqual";
+            case "Greater": return "Less";
+            case "Less": return "Greater";
+            default: return op; // Equal stays Equal
+        }
+    }
+
+    /**
+     * PAT-121a: match {@code Equal(Property(path=gender, ...), Literal("male"|"female"|...))}
+     * where the Property is rooted at an ExpressionRef("Patient") or the Patient
+     * context. Collects all literal gender values seen across the library.
+     */
+    private void tryMatchGenderFilter(JsonNode node, String type, PatientFilterInfo acc) {
+        if (!"Equal".equals(type) && !"Equivalent".equals(type)) return;
+        JsonNode ops = node.get("operand");
+        if (ops == null || !ops.isArray() || ops.size() < 2) return;
+        String literal = extractGenderLiteral(ops.get(0), ops.get(1));
+        if (literal == null) literal = extractGenderLiteral(ops.get(1), ops.get(0));
+        if (literal != null && !acc.getGender().contains(literal)) {
+            acc.getGender().add(literal);
+        }
+    }
+
+    private String extractGenderLiteral(JsonNode propNode, JsonNode litNode) {
+        if (propNode == null || litNode == null) return null;
+        if (!"Literal".equals(litNode.path("type").asText(""))) return null;
+        JsonNode unwrapped = unwrapToProperty(propNode);
+        if (unwrapped == null) return null;
+        // Accept Property(path=gender) OR Property(path=value, source=Property(path=gender))
+        String path = unwrapped.path("path").asText("");
+        if ("value".equals(path)) {
+            JsonNode inner = unwrapped.get("source");
+            if (inner != null && "Property".equals(inner.path("type").asText(""))
+                    && "gender".equals(inner.path("path").asText(""))) {
+                return litNode.path("value").asText(null);
+            }
+        } else if ("gender".equals(path)) {
+            return litNode.path("value").asText(null);
+        }
+        return null;
     }
 
     /**
@@ -500,6 +668,48 @@ public class DataRequirementExtractor {
                 }
             }
         }
+
+        // PAT-121b: detect StartsWith(Coding.code.value, 'E08') and capture the prefix.
+        // Very common in clinical CQL to match ICD-10 code ranges without enumerating
+        // every code ("E08-E13" = diabetes). Accept the built-in StartsWith ELM node
+        // AND user-defined function wrappers such as `CodeStartsWith` (case
+        // insensitive "startsWith" substring) that many shared libraries provide.
+        boolean isStartsWith = "StartsWith".equals(type)
+                || ("FunctionRef".equals(type)
+                        && node.path("name").asText("").toLowerCase().contains("startswith"));
+        if (isStartsWith) {
+            JsonNode ops = node.get("operand");
+            if (ops != null && ops.isArray() && ops.size() >= 2) {
+                String prefix = extractStartsWithPrefix(ops.get(0), ops.get(1), innerAlias);
+                if (prefix != null && !info.codePrefixes.contains(prefix)) {
+                    info.codePrefixes.add(prefix);
+                }
+            }
+        }
+    }
+
+    /**
+     * PAT-121b: match {@code StartsWith(Property(value → code on alias), Literal("E08"))}
+     * and return the prefix literal. Returns null if the shape doesn't match.
+     */
+    private String extractStartsWithPrefix(JsonNode propertyNode, JsonNode literalNode, String innerAlias) {
+        if (propertyNode == null || literalNode == null) return null;
+        if (!"Literal".equals(literalNode.path("type").asText(""))) return null;
+        JsonNode unwrapped = unwrapToProperty(propertyNode);
+        if (unwrapped == null) return null;
+        // Expect Property(path=value, source=Property(path=code, scope=alias))
+        // (or Property(path=code) directly — some translator versions skip the .value)
+        String outerPath = unwrapped.path("path").asText("");
+        if ("value".equals(outerPath)) {
+            JsonNode inner = unwrapped.get("source");
+            if (inner != null && "Property".equals(inner.path("type").asText(""))
+                    && "code".equals(inner.path("path").asText(""))) {
+                return literalNode.path("value").asText(null);
+            }
+        } else if ("code".equals(outerPath)) {
+            return literalNode.path("value").asText(null);
+        }
+        return null;
     }
 
     /**
@@ -518,8 +728,20 @@ public class DataRequirementExtractor {
             return null;
         }
 
-        // Check unwrapped is a Property with path "system" (or "url")
+        // Check unwrapped is a Property with path "system" (or "url").
+        // PAT-121c: CQL `Coding.system.value = 'http://...'` produces ELM
+        // Property(path="value", source=Property(path="system")). Unwrap the
+        // outer .value accessor so the actual system/url property is visible.
         String path = unwrapped.path("path").asText("");
+        if ("value".equals(path)) {
+            JsonNode inner = unwrapped.get("source");
+            if (inner != null && "Property".equals(inner.path("type").asText(""))) {
+                String innerPath = inner.path("path").asText("");
+                if ("system".equals(innerPath) || "url".equals(innerPath)) {
+                    path = innerPath;
+                }
+            }
+        }
         if (!"system".equals(path) && !"url".equals(path)) {
             return null;
         }
@@ -1032,13 +1254,24 @@ public class DataRequirementExtractor {
      * and convert to DataRequirementInfo objects.
      */
     private List<DataRequirementInfo> deduplicateRequirements(
-            List<RetrieveInfo> retrieves, Map<String, String> valueSetMap) {
+            List<RetrieveInfo> retrieves, Map<String, String> valueSetMap,
+            PatientFilterInfo patientFilter) {
 
         Map<String, DataRequirementInfo> dedupMap = new LinkedHashMap<>();
 
         for (RetrieveInfo ri : retrieves) {
             String dedupKey = buildDedupKey(ri);
             if (dedupMap.containsKey(dedupKey)) {
+                // PAT-121b: merge prefixes from duplicate Retrieves with the same codeProperty
+                // so "[Condition] C where StartsWith(C.code, 'E08') or StartsWith(C.code, 'E11')"
+                // ends up with both prefixes visible in the UI.
+                DataRequirementInfo existing = dedupMap.get(dedupKey);
+                if (!ri.codePrefixes.isEmpty() && existing.getCodeFilter() != null && !existing.getCodeFilter().isEmpty()) {
+                    CodeFilterInfo cf = existing.getCodeFilter().get(0);
+                    List<String> merged = cf.getCodePrefixes() == null ? new ArrayList<>() : new ArrayList<>(cf.getCodePrefixes());
+                    for (String p : ri.codePrefixes) if (!merged.contains(p)) merged.add(p);
+                    cf.setCodePrefixes(merged);
+                }
                 continue;
             }
 
@@ -1047,7 +1280,8 @@ public class DataRequirementExtractor {
 
             // Code filter from inline codes or Where clause code system
             boolean hasCodeFilter = ri.codeProperty != null
-                    && (ri.valueSetRefName != null || !ri.directCodes.isEmpty() || ri.codeSystemUrl != null);
+                    && (ri.valueSetRefName != null || !ri.directCodes.isEmpty()
+                            || ri.codeSystemUrl != null || !ri.codePrefixes.isEmpty());
             if (hasCodeFilter) {
                 CodeFilterInfo.CodeFilterInfoBuilder cfBuilder = CodeFilterInfo.builder()
                         .path(ri.codeProperty);
@@ -1067,6 +1301,10 @@ public class DataRequirementExtractor {
                     cfBuilder.code(ri.directCodes);
                 }
 
+                if (!ri.codePrefixes.isEmpty()) {
+                    cfBuilder.codePrefixes(new ArrayList<>(ri.codePrefixes));
+                }
+
                 builder.codeFilter(List.of(cfBuilder.build()));
             }
 
@@ -1075,6 +1313,11 @@ public class DataRequirementExtractor {
                 builder.dateFilter(List.of(
                         DateFilterInfo.builder().path(ri.dateProperty).build()
                 ));
+            }
+
+            // PAT-121a: attach Patient demographic filters to the Patient entry only
+            if (patientFilter != null && "Patient".equals(ri.resourceType)) {
+                builder.patientFilter(patientFilter);
             }
 
             dedupMap.put(dedupKey, builder.build());
@@ -1114,6 +1357,8 @@ public class DataRequirementExtractor {
         String codeSystemUrl;
         String codeSystemName;
         List<CodingInfo> directCodes = new ArrayList<>();
+        /** PAT-121b: prefixes captured from {@code StartsWith(Coding.code.value, 'E08')} patterns. */
+        List<String> codePrefixes = new ArrayList<>();
     }
 
     /**

--- a/backend/src/test/java/com/cqlplatform/service/cql/DataRequirementExtractorTest.java
+++ b/backend/src/test/java/com/cqlplatform/service/cql/DataRequirementExtractorTest.java
@@ -1296,6 +1296,251 @@ class DataRequirementExtractorTest {
     }
 
     @Test
+    void extract_existsWithStartsWith_capturesCodePrefix() {
+        // PAT-121b: match `exists(C.code.coding where StartsWith(Coding.code.value, 'E08'))`
+        // — common ICD-10 range pattern. The ELM shape is Exists → Query(source=coding chain)
+        // → Where(StartsWith(Property(value → code), Literal("E08"))).
+        String elmJson = """
+                {
+                  "library": {
+                    "statements": {
+                      "def": [
+                        {
+                          "name": "DiabeticConds",
+                          "expression": {
+                            "type": "Query",
+                            "source": [{ "alias": "C", "expression": { "type": "Retrieve", "dataType": "{http://hl7.org/fhir}Condition" } }],
+                            "where": {
+                              "type": "Exists",
+                              "operand": {
+                                "type": "Query",
+                                "source": [{ "alias": "Coding",
+                                    "expression": { "type": "Property", "path": "coding", "source": { "type": "Property", "path": "code", "scope": "C" } } }],
+                                "where": {
+                                  "type": "Or",
+                                  "operand": [
+                                    { "type": "StartsWith",
+                                      "operand": [
+                                        { "type": "Property", "path": "value",
+                                          "source": { "type": "Property", "path": "code", "scope": "Coding" } },
+                                        { "type": "Literal", "value": "E08" }
+                                      ]
+                                    },
+                                    { "type": "StartsWith",
+                                      "operand": [
+                                        { "type": "Property", "path": "value",
+                                          "source": { "type": "Property", "path": "code", "scope": "Coding" } },
+                                        { "type": "Literal", "value": "E11" }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+        List<DataRequirementInfo> result = extractor.extract(elmJson);
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCodeFilter().get(0).getCodePrefixes())
+                .containsExactlyInAnyOrder("E08", "E11");
+    }
+
+    @Test
+    void extract_existsWithCustomStartsWithFunction_capturesCodePrefix() {
+        // PAT-121b: user-defined CodeStartsWith(prop, literal) function — the
+        // shared-library helper that wraps the built-in StartsWith. We match
+        // FunctionRef with a name containing "startsWith" (case-insensitive).
+        String elmJson = """
+                {
+                  "library": {
+                    "statements": {
+                      "def": [
+                        {
+                          "name": "X",
+                          "expression": {
+                            "type": "Query",
+                            "source": [{ "alias": "C", "expression": { "type": "Retrieve", "dataType": "{http://hl7.org/fhir}Condition" } }],
+                            "where": {
+                              "type": "Exists",
+                              "operand": {
+                                "type": "Query",
+                                "source": [{ "alias": "Coding",
+                                    "expression": { "type": "Property", "path": "coding", "source": { "type": "Property", "path": "code", "scope": "C" } } }],
+                                "where": {
+                                  "type": "FunctionRef", "name": "CodeStartsWith",
+                                  "operand": [
+                                    { "type": "Property", "path": "value",
+                                      "source": { "type": "Property", "path": "code", "scope": "Coding" } },
+                                    { "type": "Literal", "value": "J18" }
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+        List<DataRequirementInfo> result = extractor.extract(elmJson);
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCodeFilter().get(0).getCodePrefixes())
+                .containsExactly("J18");
+    }
+
+    @Test
+    void extract_existsWithCodingSystemValue_resolvesSystemUrlViaValueUnwrap() {
+        // PAT-121c: CQL `Coding.system.value = 'http://...'` produces
+        // Property(path="value", source=Property(path="system")). Previously the
+        // extractor only matched Property(path="system") directly and missed the
+        // .value wrapper — measure 3's Condition came out with system=null.
+        String elmJson = """
+                {
+                  "library": {
+                    "statements": {
+                      "def": [
+                        {
+                          "name": "X",
+                          "expression": {
+                            "type": "Query",
+                            "source": [{ "alias": "C", "expression": { "type": "Retrieve", "dataType": "{http://hl7.org/fhir}Condition" } }],
+                            "where": {
+                              "type": "Exists",
+                              "operand": {
+                                "type": "Query",
+                                "source": [{ "alias": "Coding",
+                                    "expression": { "type": "Property", "path": "coding", "source": { "type": "Property", "path": "code", "scope": "C" } } }],
+                                "where": {
+                                  "type": "Equal",
+                                  "operand": [
+                                    { "type": "Property", "path": "value",
+                                      "source": { "type": "Property", "path": "system", "scope": "Coding" } },
+                                    { "type": "Literal", "valueType": "{urn:hl7-org:elm-types:r1}String", "value": "http://hl7.org/fhir/sid/icd-10-cm" }
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+        List<DataRequirementInfo> result = extractor.extract(elmJson);
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCodeFilter().get(0).getCodeSystemUrl())
+                .isEqualTo("http://hl7.org/fhir/sid/icd-10-cm");
+    }
+
+    @Test
+    void extract_patientFilter_collectsAgeRange() {
+        // PAT-121a: `AgeInYearsAt(...) >= 18 and AgeInYearsAt(...) <= 64`
+        // — ELM uses CalculateAge(precision=Year). minAge/maxAge are inclusive.
+        String elmJson = """
+                {
+                  "library": {
+                    "statements": {
+                      "def": [
+                        {
+                          "name": "Initial Population",
+                          "expression": {
+                            "type": "And",
+                            "operand": [
+                              { "type": "GreaterOrEqual", "operand": [
+                                  { "type": "CalculateAge", "precision": "Year",
+                                    "operand": { "type": "Property", "path": "birthDate.value", "source": { "type": "ExpressionRef", "name": "Patient" } } },
+                                  { "type": "Literal", "valueType": "{urn:hl7-org:elm-types:r1}Integer", "value": "18" }
+                              ]},
+                              { "type": "LessOrEqual", "operand": [
+                                  { "type": "CalculateAge", "precision": "Year",
+                                    "operand": { "type": "Property", "path": "birthDate.value", "source": { "type": "ExpressionRef", "name": "Patient" } } },
+                                  { "type": "Literal", "valueType": "{urn:hl7-org:elm-types:r1}Integer", "value": "64" }
+                              ]}
+                            ]
+                          }
+                        },
+                        {
+                          "name": "PatRetrieve",
+                          "expression": { "type": "Retrieve", "dataType": "{http://hl7.org/fhir}Patient" }
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+        List<DataRequirementInfo> result = extractor.extract(elmJson);
+        DataRequirementInfo patient = result.stream()
+                .filter(r -> "Patient".equals(r.getType())).findFirst().orElseThrow();
+        assertThat(patient.getPatientFilter()).isNotNull();
+        assertThat(patient.getPatientFilter().getMinAge()).isEqualTo(18);
+        assertThat(patient.getPatientFilter().getMaxAge()).isEqualTo(64);
+        assertThat(patient.getPatientFilter().getAgeUnit()).isEqualTo("Year");
+    }
+
+    @Test
+    void extract_patientFilter_collectsGender() {
+        String elmJson = """
+                {
+                  "library": {
+                    "statements": {
+                      "def": [
+                        {
+                          "name": "MaleOnly",
+                          "expression": {
+                            "type": "Equal",
+                            "operand": [
+                              { "type": "Property", "path": "value",
+                                "source": { "type": "Property", "path": "gender", "source": { "type": "ExpressionRef", "name": "Patient" } } },
+                              { "type": "Literal", "valueType": "{urn:hl7-org:elm-types:r1}String", "value": "male" }
+                            ]
+                          }
+                        },
+                        {
+                          "name": "PatRetrieve",
+                          "expression": { "type": "Retrieve", "dataType": "{http://hl7.org/fhir}Patient" }
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+        List<DataRequirementInfo> result = extractor.extract(elmJson);
+        DataRequirementInfo patient = result.stream()
+                .filter(r -> "Patient".equals(r.getType())).findFirst().orElseThrow();
+        assertThat(patient.getPatientFilter()).isNotNull();
+        assertThat(patient.getPatientFilter().getGender()).containsExactly("male");
+    }
+
+    @Test
+    void extract_patientFilter_noConstraints_leavesPatientFilterNull() {
+        // Without any age or gender comparison in the library, patientFilter
+        // stays null so measures applicable to all demographics don't show an
+        // empty filter panel.
+        String elmJson = """
+                {
+                  "library": {
+                    "statements": {
+                      "def": [
+                        { "name": "PatRetrieve", "expression": { "type": "Retrieve", "dataType": "{http://hl7.org/fhir}Patient" } }
+                      ]
+                    }
+                  }
+                }
+                """;
+        List<DataRequirementInfo> result = extractor.extract(elmJson);
+        DataRequirementInfo patient = result.stream()
+                .filter(r -> "Patient".equals(r.getType())).findFirst().orElseThrow();
+        assertThat(patient.getPatientFilter()).isNull();
+    }
+
+    @Test
     void extract_retrieveWithUnresolvableConceptRef_leavesNoCodes() {
         // When the ConceptRef name has no matching concept in library.concepts.def
         // (e.g. declared in an external library), we should gracefully extract

--- a/frontend/src/components/measure/DataRequirementsTab.tsx
+++ b/frontend/src/components/measure/DataRequirementsTab.tsx
@@ -162,8 +162,12 @@ function RequirementRows({ requirement }: { requirement: DataRequirementInfo }) 
   const { t } = useTranslation('measures')
   const hasCodeFilter = requirement.codeFilter && requirement.codeFilter.length > 0
   const hasDateFilter = requirement.dateFilter && requirement.dateFilter.length > 0
+  const hasPatientFilter = requirement.patientFilter
+    && (requirement.patientFilter.minAge != null
+        || requirement.patientFilter.maxAge != null
+        || (requirement.patientFilter.gender && requirement.patientFilter.gender.length > 0))
 
-  if (!hasCodeFilter && !hasDateFilter) {
+  if (!hasCodeFilter && !hasDateFilter && !hasPatientFilter) {
     return (
       <TableRow>
         <TableCell colSpan={3}>
@@ -177,6 +181,50 @@ function RequirementRows({ requirement }: { requirement: DataRequirementInfo }) 
 
   return (
     <>
+      {/* PAT-121a: Patient demographic filter (age / gender). Only appears on the
+          Patient row when the measure has demographic constraints — measures
+          applicable to all patients keep the row minimal. */}
+      {hasPatientFilter && requirement.patientFilter && (
+        <TableRow>
+          <TableCell>
+            <Chip label={t('dataRequirements.filterTypes.patient')} size="small" variant="outlined" color="secondary" sx={{ fontSize: '0.75rem' }} />
+          </TableCell>
+          <TableCell>
+            <Typography variant="body2" fontFamily="monospace">
+              {requirement.patientFilter.minAge != null || requirement.patientFilter.maxAge != null
+                ? 'age / gender'
+                : 'gender'}
+            </Typography>
+          </TableCell>
+          <TableCell>
+            <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+              {(requirement.patientFilter.minAge != null || requirement.patientFilter.maxAge != null) && (
+                <Chip
+                  size="small"
+                  variant="outlined"
+                  color="info"
+                  label={t('dataRequirements.ageRange', {
+                    min: requirement.patientFilter.minAge ?? '–',
+                    max: requirement.patientFilter.maxAge ?? '–',
+                    unit: requirement.patientFilter.ageUnit || 'Year',
+                  })}
+                  sx={{ fontSize: '0.7rem' }}
+                />
+              )}
+              {requirement.patientFilter.gender?.map((g) => (
+                <Chip
+                  key={g}
+                  size="small"
+                  variant="outlined"
+                  color="info"
+                  label={t('dataRequirements.gender', { value: g })}
+                  sx={{ fontSize: '0.7rem' }}
+                />
+              ))}
+            </Stack>
+          </TableCell>
+        </TableRow>
+      )}
       {requirement.codeFilter?.map((cf, i) => (
         <TableRow key={`code-${i}`}>
           <TableCell>
@@ -226,6 +274,24 @@ function RequirementRows({ requirement }: { requirement: DataRequirementInfo }) 
                     size="small"
                     variant="outlined"
                     title={c.system ? `${c.system}|${c.code}` : c.code}
+                    sx={{ fontSize: '0.7rem' }}
+                  />
+                ))}
+              </Stack>
+            )}
+            {/* PAT-121b: code prefixes from StartsWith patterns ("any ICD-10 code
+                starting with E08"). Rendered distinct from exact-code chips so
+                authors see this is a range match, not an enumerated list. */}
+            {cf.codePrefixes && cf.codePrefixes.length > 0 && (
+              <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap sx={{ mt: 0.5 }}>
+                {cf.codePrefixes.map((p, j) => (
+                  <Chip
+                    key={`prefix-${j}`}
+                    label={`${p}*`}
+                    size="small"
+                    variant="outlined"
+                    color="warning"
+                    title={t('dataRequirements.prefixTooltip', { prefix: p })}
                     sx={{ fontSize: '0.7rem' }}
                   />
                 ))}

--- a/frontend/src/locales/en/measures.json
+++ b/frontend/src/locales/en/measures.json
@@ -413,8 +413,12 @@
       "valueSet": "Value Set",
       "codeSystem": "Code System",
       "date": "Date",
-      "dateFilter": "Date filter"
-    }
+      "dateFilter": "Date filter",
+      "patient": "Patient"
+    },
+    "ageRange": "Age {{min}}–{{max}} {{unit}}",
+    "gender": "Gender: {{value}}",
+    "prefixTooltip": "Codes starting with '{{prefix}}' (range match, not an enumerated list)"
   },
   "evaluation": {
     "title": "Evaluate: {{name}}",

--- a/frontend/src/locales/zh-TW/measures.json
+++ b/frontend/src/locales/zh-TW/measures.json
@@ -413,8 +413,12 @@
       "valueSet": "值集",
       "codeSystem": "代碼系統",
       "date": "日期",
-      "dateFilter": "日期篩選"
-    }
+      "dateFilter": "日期篩選",
+      "patient": "病人"
+    },
+    "ageRange": "年齡 {{min}}–{{max}} {{unit}}",
+    "gender": "性別：{{value}}",
+    "prefixTooltip": "代碼以「{{prefix}}」開頭（範圍比對，非列舉清單）"
   },
   "evaluation": {
     "title": "評估：{{name}}",

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1161,6 +1161,9 @@ export interface DataRequirementInfo {
   profile?: string[]
   codeFilter?: CodeFilterInfo[]
   dateFilter?: DateFilterInfo[]
+  /** PAT-121a: populated only on the Patient entry when the measure has
+   *  age / gender constraints (e.g. adult-only cohort). */
+  patientFilter?: PatientFilterInfo
 }
 
 export interface CodeFilterInfo {
@@ -1170,6 +1173,16 @@ export interface CodeFilterInfo {
   codeSystemUrl?: string
   codeSystemName?: string
   code?: CodingInfo[]
+  /** PAT-121b: code prefixes captured from `StartsWith(code, 'E08')` patterns.
+   *  Clinical CQL often groups ICD ranges by prefix rather than enumerating codes. */
+  codePrefixes?: string[]
+}
+
+export interface PatientFilterInfo {
+  minAge?: number
+  maxAge?: number
+  ageUnit?: string
+  gender?: string[]
 }
 
 export interface DateFilterInfo {


### PR DESCRIPTION
## 使用者問題

PAT-120 修完後仍有缺漏 + 「年齡性別要不要顯示」。稽核所有 6 個 production measure 找到 3 個剩餘 pattern。

## 3 個修法

### PAT-121a — 年齡/性別 filter
- 新 `PatientFilterInfo { minAge, maxAge, ageUnit, gender[] }`，只綁在 Patient 條目
- `collectPatientFilter` 遍歷 ELM 匹配 `CalculateAge` 比較 + `Patient.gender` equality
- 正規化成 inclusive range（`>= 18` → minAge=18，`> 17` → minAge=18，等等）
- 沒 constraint 時 null，不污染「所有年齡皆可」的 measure

### PAT-121b — StartsWith 代碼前綴
- Measure 2 (13 次 CodeStartsWith) + Measure 3 (7 次 StartsWith) 全部漏掉
- `RetrieveInfo.codePrefixes` 新欄位 + `CodeFilterInfo.codePrefixes` DTO 欄位
- 支援 built-in `StartsWith` 型別 + FunctionRef（name 含 \"startsWith\"，CI）涵蓋自訂 wrapper
- Dedup 時合併同 retrieve 的多個 prefix（E08 / E09 / E10...）

### PAT-121c — 巢狀 exists codeSystem 穿透
- `Coding.system.value = 'http://...'` 的 ELM = `Property(path=\"value\", source=Property(path=\"system\"))`
- 舊 matcher 只看外層 path 漏掉 .value wrapper
- 修好後 measure 3 Condition 終於能抓到 ICD-10-CM URL

## FE 顯示

- Patient 條目：年齡 + 性別 chip（secondary 色系）
- Code filter 欄位：`E08*` 樣式 warning 色 chip + tooltip 說明是範圍比對
- i18n zh-TW / en 同步

## 測試

- 6 new DataRequirementExtractorTest（prefix 內建 / prefix 自訂函式 / nested exists value-unwrap / age range / gender / 無 constraint null）
- 33/33 pass (27 既有 + 6 新)
- `tsc --noEmit` 零 error

## 部署後預期（production 驗證）

- Measure 4/5: Patient 條目顯示「年齡 18-64 Year」chip
- Measure 2: Condition 顯示 6 個 `E08*`...`E13*` chip；MedicationRequest 顯示 `A10*` chip
- Measure 3: Condition 顯示 codeSystem URL `http://hl7.org/fhir/sid/icd-10-cm`（之前 null）

## 風險

- 低。純擷取擴充 + DTO 新增欄位（後端 @NoArgsConstructor + @AllArgsConstructor 都 regen）
- 無 API break、無 DB migration
- 新欄位 FE optional，舊對接商若沒讀仍正常

## TFDA

| 需求 |
|------|
| #406 |

安全性等級：**A**（資料擷取完整性；對接商更準確但不涉臨床決策）

🤖 Generated with [Claude Code](https://claude.com/claude-code)