### PR TITLE
docs: refresh README to 2.5.0 (2026-05-04)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # CQL Platform
 
-> **Version 2.4.0** | Updated 2026-03-04
+> **Version 2.5.0** | Updated 2026-05-04
 
-A comprehensive Clinical Quality Language (CQL) development platform featuring CQL editing, translation, execution, CDS Hooks integration, CDS authoring, eCQM visual authoring with CQL generation, electronic quality measure (eCQM) evaluation, FHIR resource browsing, internationalization (i18n), and an admin dashboard with audit logging.
+A comprehensive Clinical Quality Language (CQL) development platform featuring CQL editing, translation, execution, CDS Hooks integration, CDS authoring, eCQM visual authoring with CQL generation, electronic quality measure (eCQM) evaluation, quality measure dashboards, FHIR resource browsing, EHR integration (SMART Backend Services), TW Core synthetic patient generation, AI-assisted CQL repair, an interactive Learn Center, internationalization (i18n), and an admin dashboard with audit logging. The platform is developed under an IEC 62304 / ISO 14971 / TFDA workflow with automated regulatory document generation.
 
 ## Features
 
@@ -62,6 +62,53 @@ A comprehensive Clinical Quality Language (CQL) development platform featuring C
 - Expression tree validation: XSS filtering, template/modifier ID verification, required population checks
 - Debounced auto-save with optimistic UI updates
 
+### Quality Measure Dashboard
+- Real-time dashboard for quality measure performance with department-level drilldown
+- Score trend chart: multi-line time series with target/warning threshold reference lines
+- Threshold alert panel: scoring-family-aware formatting (proportion `%`, continuous-variable `unit`, cohort integer count)
+- Score distribution chart and department average heatmap
+- Quality report panel with measure preview table and CSV/Excel export
+- Filter bar: period selector, scoring type, department scope
+- Per-measure thresholds (target / warning / critical) with `MeasureThresholdEntity` persistence
+
+### EHR Integration
+- SMART Backend Services authentication (asymmetric JWT client assertion, PKI-based)
+- TLS context factory for mutual TLS connections to hospital EHR FHIR servers
+- Connection health checks with circuit breaker and exponential backoff retry
+- Async patient import with progress tracking and resumable failure retry
+- Batch import jobs with `BatchImportJobEntity` lifecycle and `FailedImportEntity` retry queue
+- FHIR Subscription registration and event handling
+- Patient match/search across multiple EHR endpoints
+- EHR outage banner driven by `EhrOutageContext` with graceful degradation
+
+### TW Core Synthetic Patient Generator
+- Pure-frontend FHIR R4 patient bundle generator targeting TW Core IG profiles
+- Taiwan demographics (name, address, national ID with checksum, phone) — `twDemographics.ts`
+- Clinical data driven by JSON config files (`config/twcore/`) — conditions/observations/medications/allergies/scenarios — no code changes needed to add new clinical patterns
+- Bundle upload via `PUT ResourceType/id` to preserve client-side IDs (HAPI compatible)
+- Configurable scenarios for diabetes, hypertension, CKD, and custom multi-morbidity profiles
+
+### AI-Assisted CQL Repair
+- Cloud AI provider (configurable) and local Ollama provider for CQL error fix suggestions
+- Curated CQL knowledge base (`CqlKnowledgeBase` + `KnowledgeEntry`) seeds the prompt with domain-specific guidance
+- `CqlFixService` integrates translator error/warning output with prompt synthesis and applies suggested patches
+- Provider selection via `AiProviderCondition` (cloud-only, ollama-only, both, or disabled)
+- Rate-limited per `RateLimitProperties`
+
+### Learn Center
+- Interactive in-app CQL tutorials: introduction, language reference, concept guide, advanced topics, troubleshooting
+- CQL Playground with live translation/execution against synthetic data
+- CQL quiz with progress tracking
+- eCQM-specific tutorial walkthrough
+- TW Core IG guide with profile/extension explanations
+- FHIRPath ⇄ ELM crosswalk reference
+
+### Okta SSO Integration
+- OIDC authentication via Okta with PKCE flow
+- `OktaOidcService` exchanges authorization code for tokens; `OktaUserInfo` maps to internal `UserEntity`
+- JIT user provisioning with role mapping from Okta groups
+- Coexists with local username/password auth (configurable per deployment)
+
 ### CDS Hooks
 - Clinical Decision Support Hooks integration with service discovery and invocation
 - Service management: create, edit, version, rollback, enable/disable
@@ -107,9 +154,9 @@ A comprehensive Clinical Quality Language (CQL) development platform featuring C
 
 ### Internationalization (i18n)
 - Multi-language support: English (en) and Traditional Chinese (zh-TW)
-- Language switcher in header toolbar with persistent preference (localStorage)
+- Language switcher in header toolbar with persistent preference (localStorage, with Safari Private mode safe fallback via `safeStorage.ts`)
 - MUI locale integration for component-level translations
-- Namespace-based translation files: common, validation, editor, builder
+- 14 namespaces: `common`, `validation`, `editor`, `builder`, `authoring`, `ecqm`, `cds`, `fhir`, `terminology`, `measures`, `admin`, `cqlLibraries`, `landing`, `patientGenerator`
 - Help tooltips with automatic i18n key resolution
 
 ### Administration
@@ -135,13 +182,20 @@ A comprehensive Clinical Quality Language (CQL) development platform featuring C
 
 ### Security & Operations
 - JWT authentication with RBAC (admin/user roles)
-- AES-256-GCM encryption at rest, TLS in transit, hardened HTTP headers
-- Audit logging of all API access with full context and retention policy
+- JWT Token Version revocation: logout / password change / role change / account disable invalidates issued tokens within 30 seconds (Caffeine cache TTL)
+- Refresh token rotation with reuse detection
+- Account lockout after configurable failed-login threshold (V53 migration)
+- Personal API keys with bcrypt hash storage and revocation
+- AES-256-GCM encryption at rest, TLS in transit, hardened HTTP headers (HSTS, CSP)
+- Audit logging of all API access with full context, request ID correlation, and configurable retention
 - CSV injection prevention in all export endpoints (audit logs, measure reports)
-- Rate limiting, XSS sanitization, FHIR resource type whitelisting
-- Prometheus + Grafana monitoring with custom CQL/CDS/measure metrics
+- Rate limiting (`RateLimitProperties`), XSS sanitization (DOMPurify), FHIR resource type whitelisting
+- Prometheus + Grafana monitoring with custom CQL/CDS/measure metrics; Alertmanager rules
 - Resilience4j circuit breakers, connection pooling, execution thread pool with queuing
-- Kubernetes manifests, network policies, and GitHub Actions CI/CD
+- Sentry-compatible error tracking via `ErrorTrackingConfig`
+- Kubernetes manifests, network policies, sealed secrets, and GitHub Actions CI/CD
+- TFDA / IEC 62304 / ISO 14971 regulatory document generation pipeline (see `regulatory_docs/`)
+- Local integration smoke test harness (`scripts/smoke/run.sh`) covering all four scoring families end-to-end
 
 ## Project Structure
 
@@ -149,106 +203,116 @@ A comprehensive Clinical Quality Language (CQL) development platform featuring C
 ├── backend/                    # Java Spring Boot backend
 │   ├── pom.xml
 │   └── src/main/java/com/cqlplatform/
-│       ├── config/             # Spring configuration (security, async, metrics, resilience)
-│       ├── controller/         # REST API controllers
-│       │   ├── AuthController          # Login, register, password reset
-│       │   ├── CqlController           # CQL translate, validate, execute, libraries
-│       │   ├── CdsHooksController      # CDS service discovery and invocation
+│       ├── config/             # Spring config: SecurityConfig, AsyncConfig, CqlConfig, MetricsConfig,
+│       │                       # AiProperties, OktaProperties, OllamaProperties, RateLimitProperties,
+│       │                       # ErrorTrackingConfig, DataInitializer, EmailHashMigration
+│       ├── controller/         # 19 REST controllers
+│       │   ├── AuthController              # Login, register, password reset, refresh tokens
+│       │   ├── CqlController               # CQL translate, validate, execute, libraries
+│       │   ├── CdsHooksController          # CDS service discovery and invocation
 │       │   ├── CdsServiceConfigController  # CDS service management
-│       │   ├── AuthoringController     # CDS artifact CRUD, CQL generation, testing, deploy
-│       │   ├── EcqmController          # eCQM artifact CRUD, CQL generation, publish
-│       │   ├── MeasureController       # Measures, test cases, reports, schedules
-│       │   ├── FhirController          # FHIR resources, terminology, structure defs
-│       │   ├── AdminController         # User management
-│       │   ├── AuditController         # Audit dashboard
-│       │   ├── SmartConfigController   # SMART on FHIR configuration
-│       │   ├── UserApiKeyController    # Personal API key management
+│       │   ├── AuthoringController         # CDS artifact CRUD, CQL generation, testing, deploy
+│       │   ├── EcqmController              # eCQM artifact CRUD, CQL generation, publish
+│       │   ├── MeasureController           # Measures, test cases, reports, schedules, dashboard
+│       │   ├── FhirController              # FHIR resources, terminology, structure defs
+│       │   ├── EhrIntegrationController    # SMART backend services, patient import, batch jobs
+│       │   ├── DepartmentController        # Department CRUD for measure/dashboard scoping
+│       │   ├── IndicatorCatalogController  # Indicator catalog browsing
+│       │   ├── NotificationController      # In-app notifications
+│       │   ├── SandboxPresetController     # Sandbox presets for CDS/eCQM testing
+│       │   ├── SettingsController          # System settings
+│       │   ├── VersionController           # Build/version metadata
+│       │   ├── AdminController             # User management
+│       │   ├── AuditController             # Audit dashboard
+│       │   ├── SmartConfigController       # SMART on FHIR configuration
+│       │   ├── UserApiKeyController        # Personal API key management
 │       │   └── UserLibraryPrefsController  # Library favorites and recent history
-│       ├── entity/             # JPA entities
-│       ├── repository/         # Spring Data repositories
+│       ├── entity/             # 37 JPA entities (incl. EhrConnection, BatchImportJob, FhirSubscription,
+│       │                       # MeasureThreshold, IndicatorCatalog, Notification, RefreshToken)
+│       ├── repository/         # 36 Spring Data repositories
+│       ├── security/           # JWT auth, API key auth, TokenVersionService (immediate revocation)
 │       ├── service/
-│       │   ├── cql/            # CQL translation, execution, library management
-│       │   ├── fhir/           # FHIR data provider, validation, bulk export, VSAC, structure defs
-│       │   ├── cds/            # CDS Hooks: CRUD, invocation, card strategies, analytics, feedback
-│       │   ├── measure/        # eCQM evaluation, reports, scheduling, comparison
+│       │   ├── cql/            # CQL translation, execution, library management, dependency analysis
+│       │   ├── fhir/           # FHIR data provider, validation, bulk export, VSAC, EHR connection,
+│       │   │                   # SMART backend tokens, TLS context, patient import/match, subscriptions
+│       │   ├── cds/            # CDS Hooks: CRUD, invocation, card strategies, analytics, feedback, sandbox
+│       │   ├── measure/        # 27 services — eCQM evaluation, reports, scheduling, comparison,
+│       │   │                   # composite measures, batch evaluation, dashboard, indicator catalog,
+│       │   │                   # date shift, HQMF/QRDA export, human-readable rendering
 │       │   ├── authoring/      # CDS authoring: artifact CRUD, CQL generation, testing, import, validation
-│       │   └── ecqm/           # eCQM authoring: artifact CRUD, CQL builder, publish, validation
+│       │   ├── ecqm/           # eCQM authoring: artifact CRUD, CQL builder, publish, validation
+│       │   └── ai/             # CloudAiService, OllamaService, CqlFixService, CqlKnowledgeBase
 │       ├── model/              # DTOs and request/response models
 │       │   ├── auth/           # Auth and admin DTOs
 │       │   ├── audit/          # Audit log DTOs
 │       │   ├── authoring/      # Authoring DTOs (templates, modifiers, artifacts)
 │       │   ├── fhir/           # FHIR structure definition DTOs
 │       │   ├── ecqm/           # eCQM DTOs (request, response, summary, constants, publish result)
-│       │   └── measure/        # Measure-specific DTOs
+│       │   └── measure/        # Measure-specific DTOs (incl. dashboard, threshold, indicator catalog)
 │       ├── util/               # Shared utilities (CsvUtils)
+│       ├── validation/         # Input validators (XSS, FHIR type whitelist)
 │       └── exception/          # Global exception handling
 │
 ├── frontend/                   # React + TypeScript frontend
 │   ├── package.json
 │   ├── .env.example            # Environment variable template
 │   └── src/
-│       ├── i18n.ts             # i18next configuration (en + zh-TW)
+│       ├── i18n.ts             # i18next configuration (en + zh-TW, 14 namespaces)
 │       ├── components/
 │       │   ├── common/         # GradientButton, StatusChip, SectionHeader, ErrorBoundary,
 │       │   │                   # LanguageSwitcher, HelpTooltip, HelpDrawer, Skeletons, TabPanel
+│       │   ├── landing/        # Marketing landing page sections
 │       │   ├── editor/         # CqlEditor, ElmViewer, LibraryQuickAccess, VersionHistory, DiffViewer
 │       │   ├── execution/      # ExecutionPanel, DebugPanel
+│       │   ├── debug/          # Diagnostic panels for execution traces
 │       │   ├── builder/        # CqlBuilderPanel, IncludesSection, ValueSetSection, CodesSection,
 │       │   │                   # ConceptsSection, ParametersSection, DefinitionsSection, FunctionsSection,
 │       │   │                   # RetrieveBuilder, QueryBuilder, CdsCardBuilder, OperatorPanel,
 │       │   │                   # ExpressionBuilder, CqlPreviewBox, SnippetPreview
-│       │   ├── authoring/      # CDS Authoring Tool
-│       │   │   ├── ArtifactList, ArtifactModal, ArtifactWorkspace
-│       │   │   ├── builder/           # ConjunctionGroup, ArtifactElement, ModifierCard
-│       │   │   ├── element-select/    # ElementSelect, ElementSelectDropdown
-│       │   │   ├── fields/            # NumberField, StringField, ValueSetField, ChooseCodeDialog
-│       │   │   ├── subpopulations/    # Subpopulations management
-│       │   │   ├── recommendations/   # Recommendations editor
-│       │   │   ├── error-statement/   # Error statement configuration
-│       │   │   ├── base-elements/     # Base elements management
-│       │   │   ├── parameters/        # Artifact parameters
-│       │   │   ├── external-cql/      # External CQL library management
-│       │   │   ├── cql-preview/       # CQL preview panel
-│       │   │   ├── testing/           # Artifact testing interface
-│       │   │   ├── summary/           # Artifact summary view
-│       │   │   ├── import/            # CQL import dialog
-│       │   │   └── query-builder/     # Visual FHIR query builder
-│       │   ├── ecqm/           # eCQM Authoring Tool
-│       │   │   ├── EcqmArtifactList, EcqmArtifactModal, EcqmArtifactWorkspace
-│       │   │   ├── EcqmPopulationGroupsTab, EcqmPopulationGroupEditor, EcqmPopulationTreeEditor
-│       │   │   ├── EcqmObservationEditor, EcqmSdeTab, EcqmStratifiersTab
-│       │   │   └── EcqmSummaryTab, EcqmCqlPreviewTab
+│       │   ├── authoring/      # CDS Authoring Tool (11-tab workspace + builder/fields/element-select)
+│       │   ├── ecqm/           # eCQM Authoring Tool (8-tab workspace)
 │       │   ├── cds/            # CdsPanel (invoke, manage, analytics, sandbox)
-│       │   ├── measure/        # MeasureEditor, MeasureLibrary, WorkflowIndicator, PopulationCriteriaTab, etc.
-│       │   ├── testcase-builder/  # VisualBundleBuilder, ResourceForm, ElementField, FHIR field components
+│       │   ├── measure/        # MeasureEditor, MeasureLibrary, WorkflowIndicator, PopulationCriteriaTab
+│       │   ├── dashboard/      # ScoreTrendChart, ThresholdAlertPanel, QualityReportPanel,
+│       │   │                   # ScoreDistributionChart, DepartmentDrilldownChart, DashboardFilterBar
+│       │   ├── cql-libraries/  # Library workspace (editor, metadata, dependency, history, sharing tabs)
+│       │   ├── ehr/            # EHR connection forms, patient import dialog/history, search
+│       │   ├── patient-generator/ # TW Core IG synthetic patient generator (7 components)
+│       │   ├── learn/          # In-app Learn Center (tutorials, playground, quiz, cheat sheet)
+│       │   ├── testcase-builder/  # VisualBundleBuilder, ResourceForm, ElementField
 │       │   ├── fhir/           # FhirBrowser
 │       │   ├── terminology/    # TerminologyBrowser
 │       │   ├── layout/         # Header, Footer
-│       │   └── auth/           # ProtectedRoute
+│       │   └── auth/           # ProtectedRoute, login/forgot-password forms
 │       ├── contexts/           # NotificationContext, PreferencesContext, LibraryHistoryContext,
-│       │                       # BundleBuilderContext, ResourceTypeContext
-│       ├── hooks/              # useCql, useCdsHooks, useMeasures, useCqlStructure, useFhirMetadata,
-│       │                       # useAuthoring, useArtifactCql, useArtifactTesting, useExternalCql,
-│       │                       # useCqlImport, useModifiers, useTemplates, useTwcoreCatalog,
-│       │                       # useLibraryPrefs, useTerminology, useUnsavedChangesGuard, useEcqm, etc.
-│       ├── pages/              # EditorPage, CdsPage, AuthoringPage, EcqmPage, MeasuresPage,
-│       │                       # MeasureDashboardPage, FhirPage, TerminologyPage, AdminUsersPage,
-│       │                       # AuditDashboardPage, LoginPage, ForgotPasswordPage, ResetPasswordPage
-│       ├── locales/            # i18n translation files
-│       │   ├── en/             # English (common, validation, editor, builder)
-│       │   └── zh-TW/          # Traditional Chinese (common, validation, editor, builder)
-│       ├── api/                # Axios API clients (configurable base URLs)
+│       │                       # BundleBuilderContext, ResourceTypeContext, EhrOutageContext,
+│       │                       # TerminologyDrawerContext
+│       ├── hooks/              # 36 custom hooks (useCql, useMeasures, useAuthoring, useEcqm,
+│       │                       # usePatientGenerator, useEhrConnection, useDashboard, useLibraryPrefs, …)
+│       ├── pages/              # 17 pages — EditorPage, CdsPage, AuthoringPage, EcqmPage, MeasuresPage,
+│       │                       # MeasureDashboardPage, FhirPage, TerminologyPage, CqlLibrariesPage,
+│       │                       # PatientGeneratorPage, LearnPage, LandingPage, AdminUsersPage,
+│       │                       # AuditDashboardPage, LoginPage, ForgotPasswordPage, ResetPasswordPage,
+│       │                       # OktaCallbackPage
+│       ├── locales/            # i18n translation files (14 namespaces × 2 languages)
+│       │   ├── en/             # common, validation, editor, builder, authoring, ecqm, cds, fhir,
+│       │   │                   # terminology, measures, admin, cqlLibraries, landing, patientGenerator
+│       │   └── zh-TW/          # (same 14 namespaces, Traditional Chinese)
+│       ├── api/                # 19 Axios API client modules
+│       ├── config/             # twcore/ — TW Core synthetic patient generator JSON config
 │       ├── store/              # Redux slices (auth, editor, execution, artifact)
-│       ├── utils/              # CQL syntax, validation utilities
-│       ├── constants/          # Help content, eCQM scoring/population constants
+│       ├── utils/              # 24 modules — cqlSyntax, dashboardFormat, fhirPatientGenerator,
+│       │                       # twDemographics, scoringFamily, safeStorage, random, …
+│       ├── constants/          # 17 modules — timing, layout, queryConstants, eCQM scoring/population
 │       ├── theme.ts            # MUI theme with light/dark mode and locale support
 │       └── types/              # TypeScript interfaces
 │
 ├── docker/                     # Docker configuration
-│   ├── docker-compose.yml      # Production (only port 80 exposed)
+│   ├── docker-compose.yml      # Production (only port 80/443 exposed)
 │   ├── docker-compose.dev.yml  # Dev overlay (all ports exposed)
+│   ├── docker-compose.dev-pg.yml # Local Postgres-only for backend dev
 │   ├── .env.example            # Secrets template
-│   ├── nginx.conf              # Reverse proxy with Grafana/Prometheus
+│   ├── nginx.conf              # Reverse proxy with TLS, Grafana, Prometheus
 │   ├── alertmanager.yml        # Alert routing
 │   ├── prometheus.yml          # Metrics scraping
 │   ├── prometheus-alerts.yml   # Alert rules
@@ -257,26 +321,41 @@ A comprehensive Clinical Quality Language (CQL) development platform featuring C
 ├── e2e/                        # Playwright end-to-end tests
 ├── twcore/                     # TWCore synthetic patient data generator (Python)
 ├── TWCOREDATA/                 # Taiwan Core FHIR patient data and IG material
-├── k8s/                        # Kubernetes manifests
+├── k8s/                        # Kubernetes manifests (incl. sealed secrets, network policies, staging)
 ├── load-tests/                 # k6 load testing scripts
-├── docs/                       # Admin guide, deployment guide, runbooks
-└── .github/workflows/          # CI/CD pipelines
+├── scripts/
+│   ├── smoke/                  # Integration smoke test harness (one canonical scenario per scoring family)
+│   ├── changelog/              # CHANGE_LOG hash backfill helpers
+│   ├── apply-staging.sh        # Staging deploy helper
+│   └── seal-secrets.sh         # Sealed-secrets utility
+├── regulatory_docs/            # TFDA / IEC 62304 / ISO 14971 document generation
+│   ├── scripts/                # generate_regulatory_docs.py, generate_test_report.py
+│   ├── templates/              # 6 Jinja2 templates (SRS, SDS, risk, verification, traceability, change control)
+│   └── output/                 # Generated documents
+├── docs/                       # Admin guide, deployment guide, runbooks, ADRs, compliance
+└── .github/workflows/          # CI/CD: ci, deploy, release, regulatory-check, regulatory-docs,
+                                #         regulatory-snapshot, changelog-backfill
 ```
 
 ## Prerequisites
 
-- Java 17+
+- Java 21+
 - Node.js 18+
-- Maven 3.8+
-- Docker & Docker Compose (optional)
+- Maven 3.9+
+- PostgreSQL 16 (or use the bundled `docker-compose.dev-pg.yml`)
+- Docker & Docker Compose (recommended for dev)
 
 ## Quick Start
 
 ### Backend
 
 ```bash
+# Start a local Postgres (first time only)
+docker compose -f docker/docker-compose.dev-pg.yml up -d
+
+# Run the backend (uses dev profile against local Postgres)
 cd backend
-mvn spring-boot:run
+mvn spring-boot:run -Dspring-boot.run.profiles=dev
 ```
 
 The backend starts at `http://localhost:8080`.
@@ -476,11 +555,52 @@ This starts all services with exposed ports:
 | `/api/admin/audit/login-activity` | GET | Login activity |
 | `/api/admin/audit/security-events` | GET | Security events (401/403) |
 
+### EHR Integration
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/ehr/connections` | GET/POST | List / create EHR FHIR endpoints |
+| `/api/ehr/connections/{id}` | GET/PUT/DELETE | Single connection CRUD |
+| `/api/ehr/connections/{id}/health` | GET | Connection health check |
+| `/api/ehr/connections/{id}/test` | POST | Test SMART backend authentication |
+| `/api/ehr/connections/{id}/import` | POST | Trigger async patient import |
+| `/api/ehr/imports` | GET | Patient import history |
+| `/api/ehr/imports/{id}` | GET | Single import status |
+| `/api/ehr/imports/{id}/retry` | POST | Retry failed import |
+| `/api/ehr/batch-jobs` | GET/POST | Batch import jobs |
+| `/api/ehr/subscriptions` | GET/POST | FHIR Subscription registration |
+
+### Departments & Indicator Catalog
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/departments` | GET/POST/PUT/DELETE | Department CRUD for measure scoping |
+| `/api/indicator-catalog` | GET | Browse indicator catalog |
+| `/api/indicator-catalog/{id}` | GET | Single indicator detail |
+
+### Notifications & Sandbox
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/notifications` | GET | List user notifications |
+| `/api/notifications/{id}/read` | POST | Mark notification as read |
+| `/api/sandbox-presets` | GET/POST | Sandbox presets for CDS/eCQM testing |
+
+### Settings & Version
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/settings` | GET | System settings (read) |
+| `/api/settings` | PUT | Update settings (admin) |
+| `/api/version` | GET | Build metadata (commit, version, build time) |
+
 ### Other
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/.well-known/smart-configuration` | GET | SMART on FHIR configuration |
+| `/actuator/health` | GET | Spring Boot health probe |
+| `/actuator/prometheus` | GET | Prometheus metrics endpoint |
 
 ## Configuration
 
@@ -520,32 +640,53 @@ Copy `frontend/.env.example` to `frontend/.env` and customize as needed.
 | `FHIR_SERVER_URL` | FHIR server URL | `http://hapi.fhir.org/baseR4` |
 | `FHIR_TERMINOLOGY_URL` | Terminology server URL | `http://tx.fhir.org/r4` |
 | `JWT_SECRET` | JWT signing secret | (required in production) |
+| `JWT_REFRESH_SECRET` | Refresh token signing secret | (required in production) |
 | `ENCRYPTION_KEY` | AES-256 encryption key | (required in production) |
 | `SPRING_DATASOURCE_URL` | PostgreSQL connection URL | `jdbc:postgresql://localhost:5432/cqlplatform` |
+| `SPRING_PROFILES_ACTIVE` | Active Spring profile (dev/docker/prod) | `dev` |
 | `VSAC_API_KEY` | VSAC API key for terminology | (optional) |
 | `AUDIT_RETENTION_DAYS` | Audit log retention period | `365` |
+| `OKTA_ISSUER_URI` | Okta OIDC issuer URI | (optional) |
+| `OKTA_CLIENT_ID` | Okta OIDC client ID | (optional) |
+| `OKTA_CLIENT_SECRET` | Okta OIDC client secret | (optional) |
+| `AI_PROVIDER` | `cloud`, `ollama`, `both`, or `disabled` | `disabled` |
+| `AI_CLOUD_API_KEY` | API key for cloud AI provider | (required if AI cloud enabled) |
+| `OLLAMA_BASE_URL` | Local Ollama server URL | `http://localhost:11434` |
+| `RATE_LIMIT_REQUESTS_PER_MINUTE` | Per-user rate limit | `120` |
+| `EMAIL_SMTP_HOST` | SMTP host for password reset emails | (optional) |
+| `SENTRY_DSN` | Sentry DSN for error tracking | (optional) |
 
 ## Key Dependencies
 
 ### Backend
-- Spring Boot 3.2
-- CQL Framework (cql-to-elm, engine) 3.29.0
-- HAPI FHIR 7.0.0
-- CQF Clinical Reasoning 3.0.0
+- Spring Boot 3.5.12 (Java 21, Tomcat 10.1.x)
+- CQL Framework (cql-to-elm, engine) 4.5.0
+- HAPI FHIR 8.6.6
+- CQF Clinical Reasoning
 - Resilience4j 2.2.0
-- PostgreSQL 16 / H2 (dev)
-- Flyway migrations
+- PostgreSQL 16 (prod & dev) / H2 (test only)
+- Flyway 55+ forward migrations under `db/migration/` (manual rollback scripts under `db/rollback/`)
+- Caffeine in-process cache (token version, ValueSet)
 - Apache POI (Excel export)
+- FreeMarker (CQL template engine)
+- Spring Security 6.5.x with JWT
 
 ### Frontend
-- React 18 + TypeScript
-- Monaco Editor (@monaco-editor/react)
-- Material-UI 5
-- Redux Toolkit
-- TanStack Query (React Query)
-- i18next + react-i18next + i18next-browser-languagedetector
-- Axios
-- React Router 6
+- React 18 + TypeScript 5.3
+- Vite 5
+- Monaco Editor (@monaco-editor/react 4.6)
+- Material-UI 7.3
+- Redux Toolkit 2.0
+- TanStack Query (React Query) 5.x
+- i18next 25 + react-i18next 16 + i18next-browser-languagedetector
+- Axios 1.15
+- React Router 6.20
+- Recharts 3.7 (dashboard charts)
+- DOMPurify 3.3 (XSS sanitization)
+- react-window (virtualized lists)
+- react-helmet-async (head management)
+- Vitest + React Testing Library (unit tests)
+- Playwright (e2e)
 
 ## Example CQL
 
@@ -582,6 +723,32 @@ npm test
 cd e2e
 npx playwright test
 ```
+
+### Integration Smoke Test
+
+Before pushing changes that touch the CQL pipeline, run the local Docker smoke harness — it covers all four scoring families (proportion / ratio / continuous-variable / cohort) end-to-end (save → publish → evaluate):
+
+```bash
+scripts/smoke/run.sh           # Run all scenarios (~60–120s)
+scripts/smoke/run.sh --keep    # Keep stack running for debugging
+```
+
+See `scripts/smoke/README.md` for details.
+
+### TFDA / IEC 62304 Regulatory Documents
+
+Issues / PRs are written in Traditional Chinese and labelled per IEC 62304 / ISO 14971. Generated documents go to `regulatory_docs/output/`:
+
+```bash
+GITHUB_TOKEN=$(gh auth token) python regulatory_docs/scripts/generate_regulatory_docs.py \
+    --repo Lusnaker0730/CQL --version 1.0.0
+
+python regulatory_docs/scripts/generate_test_report.py \
+    --backend-reports backend/target/surefire-reports \
+    --output regulatory_docs/output --version 1.0.0
+```
+
+See `CLAUDE.md` ("TFDA 法規文件工作流") for the issue templates and CI gating rules.
 
 ### Building for Production
 


### PR DESCRIPTION
## Summary
- 同步 README 至 2026-05-04 現況，反映 PAT-127 ~ PAT-151 累積的功能與依賴版本變更
- 版本 2.4.0 → 2.5.0；Spring Boot 3.5.12 / HAPI 8.6.6 / CQL 4.5.0 / MUI 7.3 / Java 21+
- 新增 6 個功能段落（Dashboard、EHR、Patient Generator、AI Repair、Learn Center、Okta SSO）
- Project Structure / API endpoints / Env vars / Quick Start 同步現況

## Why
README 上次更新是 2026-03-04，這 2 個月期間：
- Backend 多 6 個 controllers（EhrIntegration / Department / IndicatorCatalog / Notification / SandboxPreset / Settings / Version）+ AI service + 14 個 Flyway migrations
- Frontend 多 6 個 component dirs（dashboard / cql-libraries / ehr / learn / patient-generator / debug）+ 6 個 pages
- i18n 從 4 個 namespaces 擴到 14 個
- 新增 TFDA 法規文件流程與 smoke test harness

對外（GitHub repo 首頁顯示）和對內（新進 dev / AI agent 的入口）都該反映現況。

## 關聯 Issue
無關聯 Issue（純文件，依 `regulatory-check.yml` 邏輯 `docs:` 開頭 PR 不觸發法規檢查）。

## Test plan
- [x] `wc -l README.md` 784 lines、Markdown 結構正確
- [x] 對照 `frontend/src/components/`、`backend/.../controller/` 確認段落內容真實存在
- [ ] PR diff visual 檢查 GitHub 渲染後格式無壞掉

🤖 Generated with [Claude Code](https://claude.com/claude-code)