### PR TITLE
fix: bump postgresql 42.7.10 → 42.7.11 to clear CVE-2026-42198 (#PAT-153)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -32,6 +32,8 @@
         <tomcat.version>10.1.54</tomcat.version>
         <thymeleaf.version>3.1.4.RELEASE</thymeleaf.version>
         <spring-security.version>6.5.9</spring-security.version>
+        <!-- CVE-2026-42198: client-side DoS in pgjdbc 42.7.10. Fixed in 42.7.11. -->
+        <postgresql.version>42.7.11</postgresql.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Summary

Trivy scan on PR #471 flagged `CVE-2026-42198` (HIGH, client-side DoS in pgjdbc) on the postgresql JDBC driver shipped with Spring Boot 3.5.12's BOM (42.7.10). Fix landed in 42.7.11.

Adds `<postgresql.version>42.7.11</postgresql.version>` following the existing CVE override pattern (tomcat / thymeleaf / spring-security).

## Why

- TFDA security review checks Trivy output; clearing flagged HIGH CVEs keeps the security posture clean for the next regulatory snapshot.
- Patch-level bump within 42.7.x line — no API surface change, just the DoS fix.
- Real exposure low (DoS triggers when JDBC client connects to a malicious server; we connect to our own Postgres / managed RDS), but the principle of "never ignore HIGH security findings without VEX justification" still applies.

## 關聯 Issue
- 需求: #472 (安全性等級 A — 修補 CVE-2026-42198)

## Test plan

- [x] `mvn dependency:tree -Dincludes="org.postgresql:postgresql"` resolves to 42.7.11
- [x] `mvn -f backend/pom.xml compile` 通過
- [ ] CI Trivy scan no longer lists CVE-2026-42198
- [ ] Backend test suite passes (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)