### PR TITLE
docs: attribute tutorial content as translated from HL7 CQL site

### DIFF
--- a/frontend/src/locales/en/landing.json
+++ b/frontend/src/locales/en/landing.json
@@ -4,7 +4,8 @@
     "tagline": "A CQL development platform designed for Taiwan's healthcare systems",
     "description": "Integrated with TWCORE IG specifications, providing visual CQL editing, quality measures, CDS decision support, and more to help healthcare organizations improve care quality.",
     "learnMore": "Start Learning",
-    "tryDemo": "Browse Tutorials"
+    "tryDemo": "Browse Tutorials",
+    "tutorialAttribution": "Tutorial content translated from the official HL7 CQL site (cql.hl7.org)"
   },
   "features": {
     "title": "Platform Features",

--- a/frontend/src/locales/zh-TW/landing.json
+++ b/frontend/src/locales/zh-TW/landing.json
@@ -4,7 +4,8 @@
     "tagline": "專為台灣醫療資訊系統設計的 CQL 開發平台",
     "description": "整合 TWCORE IG 規範，提供視覺化 CQL 編輯、品質量測、CDS 決策支援等完整功能，協助醫療機構提升照護品質。",
     "learnMore": "開始學習",
-    "tryDemo": "瀏覽教學"
+    "tryDemo": "瀏覽教學",
+    "tutorialAttribution": "教學內容翻譯自 HL7 CQL 官方網站 (cql.hl7.org)"
   },
   "features": {
     "title": "平台功能",

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -175,6 +175,17 @@ export default function LandingPage() {
                   {t('hero.learnMore')}
                 </Button>
               </Box>
+              <Typography
+                variant="caption"
+                sx={(theme) => ({
+                  display: 'block',
+                  mt: 1.5,
+                  color: alpha(theme.palette.common.white, 0.6),
+                  fontStyle: 'italic',
+                })}
+              >
+                {t('hero.tutorialAttribution')}
+              </Typography>
             </Box>
 
             {/* Right: Login Form */}

--- a/frontend/src/pages/LearnPage.tsx
+++ b/frontend/src/pages/LearnPage.tsx
@@ -145,6 +145,23 @@ export default function LearnPage() {
         </Box>
       </Box>
 
+      {/* Translation attribution — content adapted from HL7 CQL official site */}
+      <Box sx={(t) => ({ bgcolor: alpha(t.palette.info.main, 0.06), borderBottom: 1, borderColor: 'divider' })}>
+        <Container maxWidth="lg" sx={{ py: 0.75 }}>
+          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+            {t('hero.tutorialAttribution')}{' '}
+            <a
+              href="https://cql.hl7.org/"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: 'inherit', textDecoration: 'underline' }}
+            >
+              cql.hl7.org
+            </a>
+          </Typography>
+        </Container>
+      </Box>
+
       {/* Tabs */}
       <Box sx={{ borderBottom: 1, borderColor: 'divider', bgcolor: 'background.paper' }}>
         <Container maxWidth="lg">


### PR DESCRIPTION
## 變更說明

在使用者首次進入的兩個頁面加上明確的歸屬說明，標示 `/learn` 上的 CQL 教學內容是翻譯自 HL7 CQL 官方規格網站 (cql.hl7.org)，而非本平台原創。

## 修補內容

### `LandingPage.tsx`
- Hero 區「開始學習」按鈕下方加一行義大利體小字 caption
- 文案: 「教學內容翻譯自 HL7 CQL 官方網站 (cql.hl7.org)」/「Tutorial content translated from the official HL7 CQL site (cql.hl7.org)」

### `LearnPage.tsx`
- 在 tabs 區塊上方加一條 banner（info.main 色淡底）
- 同樣文案，外加可點擊連結到 cql.hl7.org（新分頁開啟）

### i18n
- 新 key `hero.tutorialAttribution`（en + zh-TW 同步）

## 不在本 PR

- 教學文章本身的內容檢查 / 翻譯精度審查 — 屬獨立工作
- 個別教學區塊（CqlIntroduction / ConceptGuide / AdvancedTopics 等）內部 link 仍是 cql.hl7.org，本 PR 不重新調整

🤖 Generated with [Claude Code](https://claude.com/claude-code)