### PR TITLE
fix(nginx): close /.env.<suffix> gap + 404 WordPress probe paths

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -146,13 +146,27 @@ server {
         proxy_read_timeout 180s;
     }
 
-    # PAT-160: explicit 404 on dotfile/version-control paths so recon scanners
-    # don't get a 200 OK + index.html that could look like a misconfiguration.
-    # The build image never bundles these (verified docker exec ls -la
-    # /usr/share/nginx/html/.git → No such file or directory), but cutting them
-    # off at the edge keeps the audit trail clean.
-    location ~ /\.(git|svn|hg|bzr|env|aws|ssh)(/|$) {
+    # PAT-160 + follow-up: explicit 404 on dotfile/version-control + secret
+    # file paths so recon scanners don't get a 200 OK + index.html that could
+    # look like a misconfiguration. Build image never bundles these, but
+    # cutting them off at the edge keeps the audit trail clean.
+    #
+    # NOTE: the original PAT-160 regex `/\.(env|...)(/|$)` only matched bare
+    # `/.env` and `/.env/...`. Production log analysis caught a scanner
+    # probing `/.env.production`, `/.env.bak`, `/.env.test` (note the dot
+    # after `env`) — those slipped through and returned the SPA index.html.
+    # New form `/\.(env|...)([./]|$)` also matches `/.env.<anything>`.
+    location ~ /\.(git|svn|hg|bzr|env|aws|ssh|htaccess|htpasswd|DS_Store)([./]|$) {
         deny all;
+        access_log off;
+        log_not_found off;
+        return 404;
+    }
+
+    # Block common bot recon paths (WordPress, phpMyAdmin) — we run none of
+    # these. Returning a hard 404 (instead of the SPA's index.html fallback)
+    # tells the scanner the host is uninteresting and shortens future probes.
+    location ~* ^/(wp-admin|wp-login|wp-content|wp-includes|wordpress|xmlrpc\.php|phpmyadmin|pma|adminer|administrator/index)(/|$|\.php) {
         access_log off;
         log_not_found off;
         return 404;


### PR DESCRIPTION
## 變更說明

Production log 巡檢 (三天份, 2026-05-13~15) 抓到 PAT-160 的 dotfile defense 規則有個小 gap。

### Gap #1: `.env.<suffix>` 漏網

2026-05-13 18:59 一個 scanner (`5.255.99.53`) **1 秒內** burst 13 個探測，其中：
- `/.env.production` `/.env.bak` `/.env.test` → **全部回 200 + SPA index.html (1006 bytes)** ⚠️
- 10 個 `/api/...` config endpoint → 全部 401 由 JWT auth 擋住 ✅

根因：PAT-160 的 `location ~ /\.(env|git|...)(/|$)` regex 只匹配 `/.env` 或 `/.env/...`，後面接 `.` 的不算。改成 `([./]|$)` 後 `/.env.production` 等都會 404。

### Gap #2: WordPress 探測噪音

另一個 scanner (`2a06:98c0:3600::103`) 每小時敲 `/wp-admin/install.php?step=1`，72 小時敲 14 次。我們不是 WordPress，但 SPA fallback 都回 200 → scanner 不死心。加 hard 404 rule 讓它認定主機沒興趣。

## 修補內容

`docker/nginx.conf`:

```diff
-location ~ /\.(git|svn|hg|bzr|env|aws|ssh)(/|$) {
+location ~ /\.(git|svn|hg|bzr|env|aws|ssh|htaccess|htpasswd|DS_Store)([./]|$) {
     deny all;
     access_log off;
     log_not_found off;
     return 404;
 }
+
+location ~* ^/(wp-admin|wp-login|wp-content|wp-includes|wordpress|xmlrpc\.php|phpmyadmin|pma|adminer|administrator/index)(/|$|\.php) {
+    access_log off;
+    log_not_found off;
+    return 404;
+}
```

## 驗證

- `nginx -t` 本機 docker 跑語法檢查 OK
- 不影響真實使用者流量 (SPA / `/api/*` / `/grafana/` / `/twcoredata/` / etc 路徑都不在新 rule 範圍)

## 風險

低 — 純 defense-in-depth；不擴大後端 reject 邊界、不動 storage、不變更 API contract。

🤖 Generated with [Claude Code](https://claude.com/claude-code)