### PR TITLE
test: add smoke scenario 28 exercising PAT-161/162/163/164 arithmetic emission

### DIFF
--- a/scripts/smoke/scenarios/28-arithmetic-baseelements/bundle.json
+++ b/scripts/smoke/scenarios/28-arithmetic-baseelements/bundle.json
@@ -1,0 +1,66 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "fullUrl": "Patient/smoke-28-p1",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "smoke-28-p1",
+        "meta": {"tag": [{"system": "http://smoke.test", "code": "scenario-28"}]},
+        "birthDate": "1971-06-15"
+      },
+      "request": {"method": "PUT", "url": "Patient/smoke-28-p1"}
+    },
+    {
+      "fullUrl": "Patient/smoke-28-p2",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "smoke-28-p2",
+        "meta": {"tag": [{"system": "http://smoke.test", "code": "scenario-28"}]},
+        "birthDate": "1981-04-20"
+      },
+      "request": {"method": "PUT", "url": "Patient/smoke-28-p2"}
+    },
+    {
+      "fullUrl": "Patient/smoke-28-p3",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "smoke-28-p3",
+        "meta": {"tag": [{"system": "http://smoke.test", "code": "scenario-28"}]},
+        "birthDate": "1991-08-10"
+      },
+      "request": {"method": "PUT", "url": "Patient/smoke-28-p3"}
+    },
+    {
+      "fullUrl": "Patient/smoke-28-p4",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "smoke-28-p4",
+        "meta": {"tag": [{"system": "http://smoke.test", "code": "scenario-28"}]},
+        "birthDate": "2001-12-01"
+      },
+      "request": {"method": "PUT", "url": "Patient/smoke-28-p4"}
+    },
+    {
+      "fullUrl": "Patient/smoke-28-p5",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "smoke-28-p5",
+        "meta": {"tag": [{"system": "http://smoke.test", "code": "scenario-28"}]},
+        "birthDate": "2011-05-15"
+      },
+      "request": {"method": "PUT", "url": "Patient/smoke-28-p5"}
+    },
+    {
+      "fullUrl": "Patient/smoke-28-p6",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "smoke-28-p6",
+        "meta": {"tag": [{"system": "http://smoke.test", "code": "scenario-28"}]},
+        "birthDate": "2016-11-20"
+      },
+      "request": {"method": "PUT", "url": "Patient/smoke-28-p6"}
+    }
+  ]
+}

--- a/scripts/smoke/scenarios/28-arithmetic-baseelements/expected.json
+++ b/scripts/smoke/scenarios/28-arithmetic-baseelements/expected.json
@@ -1,0 +1,11 @@
+{
+  "periodStart": "2026-01-01",
+  "periodEnd": "2026-06-30",
+  "score": 4.0,
+  "scoreTolerance": 0.001,
+  "populations": {
+    "initial-population": 4
+  },
+  "maxEvaluationTimeMs": 8000,
+  "_note": "Exercises PAT-161/162/163/164 arithmetic CQL emission. The 5 base elements above cover: (1) N-ary 3-operand mixed precedence (PAT-163 a + (b * c)), (2) unary Abs (PAT-162), (3) unary Round with precision arg (PAT-164 Round(x, N)), (4) N-ary with `mod` keyword operator (PAT-161), (5) N-ary with Quantity literal operands (PAT-161). The cohort population logic is intentionally trivial — score=4 just verifies measure evaluates after the new arithmetic emit code runs. Translation failure on any new path would 4xx the save call and fail the smoke before evaluation."
+}

--- a/scripts/smoke/scenarios/28-arithmetic-baseelements/measure.json
+++ b/scripts/smoke/scenarios/28-arithmetic-baseelements/measure.json
@@ -1,0 +1,148 @@
+{
+  "name": "SmokeArithmeticBaseElements",
+  "version": "1.0.0",
+  "description": "Smoke test scenario — exercises the PAT-161/162/163/164 arithmetic CQL emission path end-to-end. Defines 5 arithmetic base elements (one per phase feature) that aren't used in population logic; the test asserts the measure saves (CQL translates) AND evaluates to the expected cohort count. Translation failure on any new arithmetic emit path fails the smoke.",
+  "status": "draft",
+  "fhirVersion": "4.0.1",
+  "scoringType": "cohort",
+  "populationBasis": "boolean",
+  "improvementNotation": "increase",
+  "populationGroups": [
+    {
+      "groupId": "group-1",
+      "description": "Adult patient cohort (population logic intentionally trivial; the test surface is the arithmetic baseElements above)",
+      "populationBasis": "boolean",
+      "populations": {
+        "initial-population": {
+          "id": "And",
+          "name": "And",
+          "conjunction": true,
+          "returnType": "boolean",
+          "childInstances": [
+            {
+              "id": "AgeRange",
+              "name": "Age Range",
+              "type": "AgeRange",
+              "returnType": "boolean",
+              "fields": [
+                {"id": "element_name", "type": "string", "value": "Adult"},
+                {"id": "min_age", "type": "string", "value": "18"},
+                {"id": "max_age", "type": "string", "value": ""},
+                {"id": "unit_of_time", "type": "string", "value": "year"}
+              ],
+              "modifiers": []
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "supplementalData": [],
+  "stratifiers": [],
+  "baseElements": [
+    {
+      "uniqueId": "be-nary-3op-mixed-precedence",
+      "name": "BMI Threshold",
+      "type": "arithmeticExpression",
+      "returnType": "system_decimal",
+      "fields": [
+        {
+          "id": "operands",
+          "type": "json",
+          "name": "operands",
+          "value": [
+            {"mode": "literal", "operand_literal": "25"},
+            {"mode": "literal", "operand_literal": "2.5"},
+            {"mode": "literal", "operand_literal": "2"}
+          ]
+        },
+        {
+          "id": "operators",
+          "type": "json",
+          "name": "operators",
+          "value": ["+", "*"]
+        }
+      ],
+      "childInstances": [],
+      "conjunction": false
+    },
+    {
+      "uniqueId": "be-unary-abs",
+      "name": "Abs Diff",
+      "type": "arithmeticUnary",
+      "returnType": "system_decimal",
+      "fields": [
+        {"id": "function", "type": "string", "name": "function", "value": "Abs"},
+        {"id": "operand_mode", "type": "string", "name": "operand_mode", "value": "literal"},
+        {"id": "operand_literal", "type": "string", "name": "operand_literal", "value": "-15"}
+      ],
+      "childInstances": [],
+      "conjunction": false
+    },
+    {
+      "uniqueId": "be-unary-round-precision",
+      "name": "Rounded Pi",
+      "type": "arithmeticUnary",
+      "returnType": "system_decimal",
+      "fields": [
+        {"id": "function", "type": "string", "name": "function", "value": "Round"},
+        {"id": "operand_mode", "type": "string", "name": "operand_mode", "value": "literal"},
+        {"id": "operand_literal", "type": "string", "name": "operand_literal", "value": "3.14159"},
+        {"id": "precision", "type": "string", "name": "precision", "value": "2"}
+      ],
+      "childInstances": [],
+      "conjunction": false
+    },
+    {
+      "uniqueId": "be-nary-mod-keyword",
+      "name": "Mod Check",
+      "type": "arithmeticExpression",
+      "returnType": "system_integer",
+      "fields": [
+        {
+          "id": "operands",
+          "type": "json",
+          "name": "operands",
+          "value": [
+            {"mode": "literal", "operand_literal": "10"},
+            {"mode": "literal", "operand_literal": "3"}
+          ]
+        },
+        {
+          "id": "operators",
+          "type": "json",
+          "name": "operators",
+          "value": ["mod"]
+        }
+      ],
+      "childInstances": [],
+      "conjunction": false
+    },
+    {
+      "uniqueId": "be-nary-quantity-literal",
+      "name": "Quantity Sum",
+      "type": "arithmeticExpression",
+      "returnType": "system_quantity",
+      "fields": [
+        {
+          "id": "operands",
+          "type": "json",
+          "name": "operands",
+          "value": [
+            {"mode": "quantity", "operand_literal_value": "5", "operand_literal_unit": "mg/dL"},
+            {"mode": "quantity", "operand_literal_value": "3", "operand_literal_unit": "mg/dL"}
+          ]
+        },
+        {
+          "id": "operators",
+          "type": "json",
+          "name": "operators",
+          "value": ["+"]
+        }
+      ],
+      "childInstances": [],
+      "conjunction": false
+    }
+  ],
+  "parameters": []
+}


### PR DESCRIPTION
## 變更說明

PAT-161/162/163/164 整套上線後，整合層 smoke 沒有任何 scenario 真正跑過新的 arithmetic emit 路徑。Scenario 28 補上覆蓋：定義 **5 個 arithmetic baseElement**，每個對應一個 phase 的核心 emit 規則，跑完整 save → publish → evaluate pipeline。

| baseElement | Phase 覆蓋 | 內容 |
|------------|----------|------|
| BMI Threshold | **PAT-163** | N-ary 3-operand mixed precedence (`25 + 2.5 * 2` → `25 + (2.5 * 2)` 強制括號) |
| Abs Diff | **PAT-162** | arithmeticUnary `Abs(-15)` |
| Rounded Pi | **PAT-164** | arithmeticUnary `Round(3.14159, 2)` 雙參數 |
| Mod Check | **PAT-161** | N-ary `10 mod 3` (CQL keyword operator) |
| Quantity Sum | **PAT-161** | N-ary `5 'mg/dL' + 3 'mg/dL'` (Quantity literal operand) |

## 為何 baseElements 不在 population logic 中引用？

斷言面是**翻譯 + emission 路徑**，不是 evaluation：
- `saved artifact #1` 通過 = `CqlArtifactBuilder` + `ExpressionCqlEngine` 對 5 個新 emit 規則都產出 `CqlTranslationService` 可接受的 CQL
- Translation 任何一條路徑爆都會 4xx 失敗在 save，smoke 在 evaluation 前就掛
- Cohort 人口邏輯保留簡單（成年人計數 → score=4.0）讓失敗時候定位明確

## V56 Flyway migration 順帶覆蓋

Smoke harness 每次都啟一個全新 PG 容器跑全部 migrations。Scenario 28 落地後 V56 也被整合層每次 smoke 跑驗證一次，**比 production 一次性 migration 多了持續 regression 保護**。

## 本機驗證

```
✓ score: 4.0 (expected 4.0, Δ=0)
✓ initial-population: 4
✓ evaluation within budget: 2738ms (≤ 8000ms)
passed: 1 / failed: 0
```

## 風險

無 — 純測試新增，不動 production code、不動 storage、不動 CI gate。

🤖 Generated with [Claude Code](https://claude.com/claude-code)