### PR TITLE
fix: configure Monaco web workers (PAT-165 follow-up)

### DIFF
--- a/frontend/src/components/common/MonacoEditor.tsx
+++ b/frontend/src/components/common/MonacoEditor.tsx
@@ -34,6 +34,35 @@ import type {
   DiffEditorProps,
 } from '@monaco-editor/react'
 
+// PAT-165 follow-up: explicit Monaco worker configuration.
+// When Monaco was loaded from jsdelivr CDN (pre-PAT-157), its loader.js
+// configured MonacoEnvironment for us automatically. After self-hosting via
+// PR #521 and lazy-loading via PR #526, no one tells Monaco where to find
+// its workers — the editor then logs "Could not create web worker(s)" and
+// falls back to running worker code on the main thread (UI freezes on
+// heavy ops). Below uses Vite's `?worker` query so each worker is bundled
+// as a separate chunk loaded lazily on demand.
+import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
+import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker'
+import cssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker'
+import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker'
+import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
+
+// `self.MonacoEnvironment` is the contract Monaco looks for. Set at module
+// scope so it's in place before any Editor mounts. Workers map by language
+// label; the default catch-all is the core editor worker (handles syntax
+// highlighting and tokenization for languages without a dedicated worker —
+// our custom CQL syntax falls into this bucket).
+;(globalThis as unknown as { MonacoEnvironment: monaco.Environment }).MonacoEnvironment = {
+  getWorker(_workerId: string, label: string) {
+    if (label === 'json') return new jsonWorker()
+    if (label === 'css' || label === 'scss' || label === 'less') return new cssWorker()
+    if (label === 'html' || label === 'handlebars' || label === 'razor') return new htmlWorker()
+    if (label === 'typescript' || label === 'javascript') return new tsWorker()
+    return new editorWorker()
+  },
+}
+
 // Module-scope side effect — runs once when this module is first imported by
 // any editor component, before Editor mounts.
 loader.config({ monaco })


### PR DESCRIPTION
## Bug

Production console after #521 + #526:
\`\`\`
Could not create web worker(s). Falling back to loading web worker code in
main thread, which might cause UI freezes.

You must define a function MonacoEnvironment.getWorkerUrl or
MonacoEnvironment.getWorker
\`\`\`

## Root cause

When Monaco loaded from jsdelivr CDN (pre-PAT-157), its loader.js configured
\`MonacoEnvironment\` for us automatically. After self-hosting via #521 +
lazy-loading via #526, no one tells Monaco where to find its workers. The
editor degrades to main-thread execution — UI freezes on heavy ops like
syntax tokenization, validation, snippets.

## Fix

\`MonacoEditor.tsx\` wrapper now sets \`globalThis.MonacoEnvironment.getWorker\`
using Vite's \`?worker\` import syntax. Each worker bundles into its own chunk
loaded on demand:

| Language label | Worker chunk |
|---|---|
| \`json\` (FHIR resource editor) | json.worker 383 KB |
| \`css\` / \`scss\` / \`less\` | css.worker 1030 KB |
| \`html\` / \`handlebars\` / \`razor\` | html.worker 693 KB |
| \`typescript\` / \`javascript\` | ts.worker 7010 KB |
| (default — incl. CQL custom language) | editor.worker 252 KB |

Worker chunks are sibling lazy chunks — only fetched when the corresponding
language is used in a mounted editor. Main entry stays 536 KB / 178 KB gzip.

## TFDA 追溯

關聯 #522 (需求) / #523 (設計) / #524 (風險) / #525 (驗證) — 與 PR #521 同 family。

🤖 Generated with [Claude Code](https://claude.com/claude-code)