### PR TITLE
fix(docker): bump Node heap to 4g for Vite build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,7 +11,12 @@ RUN npm ci
 # Copy source
 COPY . .
 
-# Build the application
+# Build the application.
+# NODE_OPTIONS heap bump: Vite bundling the Monaco-editor vendor chunk
+# (3.7 MB raw, ~970 KB gzipped) plus the rest of the app pushes
+# Rollup's analysis phase past Node's default ~2 GB heap on CI runners.
+# 4 GB gives plenty of headroom while staying well under runner limits.
+ENV NODE_OPTIONS=--max-old-space-size=4096
 RUN npm run build
 
 # Production stage


### PR DESCRIPTION
Production main's frontend Docker build broke after #528 merged:
\`\`\`
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
\`\`\`

Vite bundling self-hosted monaco-editor (3.7 MB / 970 KB gzip) through
Rollup pushed Node past its default 2GB old-space.

Add `ENV NODE_OPTIONS=--max-old-space-size=4096` before \`RUN npm run build\`.

關聯 #522 #523 #524 #525 (PAT-165 family follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)