### PR TITLE
fix: CV per-group path reads observation from raw results (#BUG-NNN)

### DIFF
--- a/backend/src/main/java/com/cqlplatform/service/measure/MeasureEvaluationService.java
+++ b/backend/src/main/java/com/cqlplatform/service/measure/MeasureEvaluationService.java
@@ -372,7 +372,7 @@ public class MeasureEvaluationService {
                     Map<String, CqlExecutionResponse.ExpressionResult> canonical =
                             populationEvaluator.buildExpressionMap(g, results);
                     if (isCv) {
-                        populationEvaluator.aggregateCvPatientResults(counts, canonical, observationValues);
+                        populationEvaluator.aggregateCvPatientResults(counts, canonical, results, observationValues);
                     } else if (isRatio) {
                         populationEvaluator.aggregateRatioPatientResults(counts, canonical);
                     } else {

--- a/backend/src/main/java/com/cqlplatform/service/measure/PopulationEvaluator.java
+++ b/backend/src/main/java/com/cqlplatform/service/measure/PopulationEvaluator.java
@@ -141,13 +141,38 @@ public class PopulationEvaluator {
     /**
      * Aggregates a single patient's CQL results for continuous-variable measures.
      * Collects observation values into the shared accumulator list.
+     *
+     * <p>Convenience overload: uses the same map for population lookup and
+     * observation extraction. Suitable for the legacy single-group path where
+     * raw CQL results are passed directly.
      */
     public void aggregateCvPatientResults(Map<String, Integer> counts,
                                            Map<String, CqlExecutionResponse.ExpressionResult> results,
                                            List<Double> observationValues) {
-        boolean inInitPop = isPopulationTrue(results, "Initial Population");
-        boolean inMeasurePop = inInitPop && isPopulationTrue(results, "Measure Population");
-        boolean excluded = inMeasurePop && isPopulationTrue(results, "Measure Population Exclusion");
+        aggregateCvPatientResults(counts, results, results, observationValues);
+    }
+
+    /**
+     * Aggregates a single patient's CQL results for continuous-variable measures
+     * with separate maps for population lookup and observation extraction.
+     *
+     * <p>The per-group eCQM path canonicalizes suffixed population define names
+     * ({@code "Initial Population 1"} → {@code "Initial Population"}) into a
+     * filtered map, but that map intentionally only contains the
+     * {@code PopulationDefinition} entries. {@code "Measure Observation Value"}
+     * / {@code "Measure Observation Values"} are top-level CQL defines (not
+     * populations), so they exist only in the raw {@code allResults} map.
+     * Passing the same canonical map for both lookups caused the observation
+     * extraction to find nothing → CV measureScore stuck at {@code null}
+     * (BUG-474 follow-up regression — surfaced by smoke scenarios 03 / 05–09).
+     */
+    public void aggregateCvPatientResults(Map<String, Integer> counts,
+                                           Map<String, CqlExecutionResponse.ExpressionResult> populationResults,
+                                           Map<String, CqlExecutionResponse.ExpressionResult> allResults,
+                                           List<Double> observationValues) {
+        boolean inInitPop = isPopulationTrue(populationResults, "Initial Population");
+        boolean inMeasurePop = inInitPop && isPopulationTrue(populationResults, "Measure Population");
+        boolean excluded = inMeasurePop && isPopulationTrue(populationResults, "Measure Population Exclusion");
         boolean effectiveMp = inMeasurePop && !excluded;
 
         if (inInitPop) increment(counts, "Initial Population");
@@ -155,10 +180,11 @@ public class PopulationEvaluator {
         if (excluded) increment(counts, "Measure Population Exclusion");
 
         if (effectiveMp) {
-            // Collect observation values — try episode-based list first, then patient-based scalar
-            List<Double> values = extractObservationValues(results, OBSERVATION_VALUES_EXPR);
+            // Observation defines aren't in the canonical population map — read from raw results.
+            // Try episode-based list first, then patient-based scalar.
+            List<Double> values = extractObservationValues(allResults, OBSERVATION_VALUES_EXPR);
             if (values.isEmpty()) {
-                values = extractObservationValues(results, OBSERVATION_VALUE_EXPR);
+                values = extractObservationValues(allResults, OBSERVATION_VALUE_EXPR);
             }
             observationValues.addAll(values);
         }

--- a/backend/src/test/java/com/cqlplatform/service/measure/PopulationEvaluatorTest.java
+++ b/backend/src/test/java/com/cqlplatform/service/measure/PopulationEvaluatorTest.java
@@ -182,6 +182,51 @@ class PopulationEvaluatorTest {
     }
 
     @Test
+    void aggregateCv_perGroupPath_readsObservationFromRawResultsNotCanonicalMap() {
+        // Regression lock for BUG-474 follow-up.
+        // The per-group eCQM path canonicalizes suffixed population define names ("Initial
+        // Population 1" → "Initial Population") into a FILTERED map containing only
+        // PopulationDefinition entries. "Measure Observation Value" is a top-level CQL
+        // define (not a population), so it only lives in the raw results map. The pre-fix
+        // 3-arg aggregateCvPatientResults received the canonical map for BOTH lookups,
+        // which silently dropped every patient's observation → measureScore stuck at null
+        // (smoke scenarios 03/05–09 all surfaced as `score: null`).
+        Map<String, CqlExecutionResponse.ExpressionResult> canonical = new LinkedHashMap<>();
+        canonical.put("Initial Population", boolResult(true));
+        canonical.put("Measure Population", boolResult(true));
+        // Raw results has BOTH the canonical population entries AND the observation define.
+        Map<String, CqlExecutionResponse.ExpressionResult> raw = new LinkedHashMap<>(canonical);
+        raw.put("Measure Observation Value", boolResult(true));
+
+        java.util.List<Double> observationValues = new java.util.ArrayList<>();
+        Map<String, Integer> counts = evaluator.initializeCvPopulationCounts();
+
+        evaluator.aggregateCvPatientResults(counts, canonical, raw, observationValues);
+
+        assertThat(counts.get("Initial Population")).isEqualTo(1);
+        assertThat(counts.get("Measure Population")).isEqualTo(1);
+        // The fix: observation extracted from raw map → 1 boolean TRUE = 1.0
+        assertThat(observationValues).containsExactly(1.0);
+    }
+
+    @Test
+    void aggregateCv_legacyTwoArgOverload_stillWorks() {
+        // The legacy single-group path passes the same raw map for both lookups — make sure
+        // the 2-arg convenience overload keeps the same behavior after the 3-map refactor.
+        Map<String, CqlExecutionResponse.ExpressionResult> raw = new LinkedHashMap<>();
+        raw.put("Initial Population", boolResult(true));
+        raw.put("Measure Population", boolResult(true));
+        raw.put("Measure Observation Value", boolResult(true));
+
+        java.util.List<Double> observationValues = new java.util.ArrayList<>();
+        Map<String, Integer> counts = evaluator.initializeCvPopulationCounts();
+
+        evaluator.aggregateCvPatientResults(counts, raw, observationValues);
+
+        assertThat(observationValues).containsExactly(1.0);
+    }
+
+    @Test
     void ratio_noDenomExceptionsConcept() {
         // Ratio doesn't have Denominator Exceptions (proportion-only per FHIR spec).
         // Even if the map had one, ratio aggregation ignores it.


### PR DESCRIPTION
## 變更說明

修補 BUG-474 引入的 follow-up regression — 多 population group eCQM 評估在 CV (continuous-variable) scoring type 下，所有 \`measureScore\` 永遠是 \`null\`。

### 根因

BUG-474 PR (#477, 2026-05-07) 把 CV 評估從單一 \`results\` map 拆成 per-group \`canonical\` map（透過 \`PopulationEvaluator.buildExpressionMap\` 對每個 group 把 suffixed 名稱 \"Initial Population 1\" 重新對到 canonical 名稱 \"Initial Population\"）。問題：\`buildExpressionMap\` 只搬 PopulationDefinition entries，不搬 top-level defines。\`\"Measure Observation Value\"\` 是 top-level define 不是 population，所以 canonical 永遠沒有它。

\`MeasureEvaluationService\` line 374 把 canonical 同時當 population lookup 也當 observation lookup map 給 \`aggregateCvPatientResults\` → 每個 patient 的 observation 都 extract 不到 → \`observationValues\` 全空 → \`if (!state.observationValues.isEmpty())\` false → \`measureScore = null\`。

### 為什麼 unit tests 都綠但 smoke 才抓到

- \`MeasureEvaluationServiceTest\` 主要 mock CQL execution，不走真實 per-group 路徑
- \`PopulationEvaluatorTest\` 用 \`results(ip, denom, numer)\` helper，傳同一個 map 給 legacy 2-arg \`aggregateCvPatientResults\`（恰巧 hit legacy path）
- legacy \`groupDefs.isEmpty()\` 路徑（line 362）傳的是 raw \`results\`，**不會踩到 canonical 缺項問題**
- 所以本 bug 只在「published 過、有 group definition 的 multi/single-group CV measure」+「per-group 路徑」才會跑到，**只有 smoke 同時跑這條 path + 驗 measureScore**

### 影響範圍（smoke scenarios 全失敗）

| Scenario | scoringType | 期望 | 實際 |
|----------|-------------|------|------|
| 03-cv-count-adults | CV Count (patient-based) | 3.0 | null |
| 05-cv-avg-encounter-duration | CV Average (episode-based) | 6.0 | null |
| 06-cv-sum-encounter-duration | CV Sum | 30.0 | null |
| 07-cv-median-encounter-duration | CV Median | 6.0 | null |
| 08-cv-min-encounter-duration | CV Min | 2.0 | null |
| 09-cv-max-encounter-duration | CV Max | 10.0 | null |

非 CV scoring types 全 22 個 scenarios 不受影響。

### 修補

把 \`aggregateCvPatientResults\` 拆成兩個 overload：

\`\`\`java
// Legacy / single-group convenience overload — 行為不變
public void aggregateCvPatientResults(counts, results, observationValues)

// 新版 — population lookup 跟 observation lookup 各用各的 map
public void aggregateCvPatientResults(counts, populationResults, allResults, observationValues)
\`\`\`

\`MeasureEvaluationService\` 的 per-group 路徑改呼叫 4-arg 版：\`(counts, canonical, results, observationValues)\`，population 找 canonical（已 rename）、observation 找 raw（有 top-level defines）。

## 變更類型

- [x] 錯誤修復 (fix) — 影響臨床評估正確性

## 關聯 Issue

BUG-474 follow-up — 由 PR #533 的 local smoke run 揭出，但**本 bug 與 #533 (Spring Boot 4 升級) 無關**，是 BUG-474 PR (#477, 2026-05-07) 引入的長期掩蓋 bug。

## 測試紀錄

- [x] 後端測試通過 — 新增 2 個 unit test 鎖 regression：
  - \`aggregateCv_perGroupPath_readsObservationFromRawResultsNotCanonicalMap\` — 鎖新 3-map 路徑
  - \`aggregateCv_legacyTwoArgOverload_stillWorks\` — legacy 2-arg overload 行為不變
- [ ] 本機 smoke run \`scripts/smoke/run.sh\` — 等 CI 綠後 merge 前手動跑

## 風險評估

| 項目 | 說明 |
|------|------|
| 風險等級 | 中 |
| 影響範圍 | CV scoring type measure evaluation — 從 2026-05-07 以來所有 published CV measure 都拿 null score |
| 回歸風險 | 低 — fix 是純 additive overload，legacy 2-arg 行為 delegate 到新 3-arg、unit test 鎖住兩條路徑 |

## 安全性確認

- [x] 此變更涉及安全性等級 **B** — 影響臨床評估正確性（CV measure score 從 null 變正確值，臨床判讀依據改變）
- [x] 已評估 OWASP Top 10 — 純內部邏輯修補，無 input 路徑改動
- [x] 無新硬編碼敏感資訊

## 設計審查備註

兩個 overload 的選擇理由：legacy 2-arg callers（\`MeasureEvaluationService\` line 362 legacy single-group path、舊單元測試）行為完全不變。新 caller 走 3-map 版 explicit 表達意圖。

未來可能改進：multi-group CV 帶 per-group suffixed observation defines（\"Measure Observation Value 1\" / \"... 2\"）— 目前 fix 把 observation 從 raw \`results\` 抓，多 group 共用同一個 raw map 沒分。**這是已知 limitation**（per BUG-474 PR 的 commit comment），\"out of scope for this PR which lands proportion multi-group. Tracked for follow-up.\" — 不在本 PR 處理。

## IEC 62304 / ISO 14971 追溯

| 法規項目 | 關聯 Issue |
|----------|-----------|
| 軟體需求 | (待補開 — 安全性等級 B 影響臨床評估正確性) |
| 軟體設計 | (同上) |
| 風險分析 | (同上) |
| 驗證紀錄 | 本 PR 新增 2 個 unit test + 本機 smoke 6 個 CV scenarios |

🤖 Generated with [Claude Code](https://claude.com/claude-code)