### PR TITLE
fix: migrate ArtifactList to react-window 2.x List API (Closes #113)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "@reduxjs/toolkit": "^2.0.0",
         "@tanstack/react-query": "^5.100.10",
         "@types/dompurify": "^3.0.5",
-        "@types/react-window": "^1.8.8",
+        "@types/react-window": "^2.0.0",
         "axios": "^1.15.0",
         "dompurify": "^3.3.3",
         "i18next": "^25.8.11",
@@ -29,7 +29,7 @@
         "react-i18next": "^16.5.4",
         "react-redux": "^9.0.0",
         "react-router-dom": "^6.20.0",
-        "react-window": "^1.8.11",
+        "react-window": "^2.2.7",
         "recharts": "^3.7.0"
       },
       "devDependencies": {
@@ -2563,12 +2563,13 @@
       }
     },
     "node_modules/@types/react-window": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.8.tgz",
-      "integrity": "sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-2.0.0.tgz",
+      "integrity": "sha512-E8hMDtImEpMk1SjswSvqoSmYvk7GEtyVaTa/GJV++FdDNuMVVEzpAClyJ0nqeKYBrMkGiyH6M1+rPLM0Nu1exQ==",
+      "deprecated": "This is a stub types definition. react-window provides its own type definitions, so you do not need this installed.",
       "license": "MIT",
       "dependencies": {
-        "@types/react": "*"
+        "react-window": "*"
       }
     },
     "node_modules/@types/semver": {
@@ -5946,27 +5947,14 @@
       }
     },
     "node_modules/react-window": {
-      "version": "1.8.11",
-      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
-      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-2.2.7.tgz",
+      "integrity": "sha512-SH5nvfUQwGHYyriDUAOt7wfPsfG9Qxd6OdzQxl5oQ4dsSsUicqQvjV7dR+NqZ4coY0fUn3w1jnC5PwzIUWEg5w==",
       "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "memoize-one": ">=3.1.1 <6"
-      },
-      "engines": {
-        "node": ">8.0.0"
-      },
       "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
-    },
-    "node_modules/react-window/node_modules/memoize-one": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
-      "license": "MIT"
     },
     "node_modules/recharts": {
       "version": "3.7.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     "@reduxjs/toolkit": "^2.0.0",
     "@tanstack/react-query": "^5.100.10",
     "@types/dompurify": "^3.0.5",
-    "@types/react-window": "^1.8.8",
+    "@types/react-window": "^2.0.0",
     "axios": "^1.15.0",
     "dompurify": "^3.3.3",
     "i18next": "^25.8.11",
@@ -34,7 +34,7 @@
     "react-i18next": "^16.5.4",
     "react-redux": "^9.0.0",
     "react-router-dom": "^6.20.0",
-    "react-window": "^1.8.11",
+    "react-window": "^2.2.7",
     "recharts": "^3.7.0"
   },
   "devDependencies": {

--- a/frontend/src/components/authoring/ArtifactList.tsx
+++ b/frontend/src/components/authoring/ArtifactList.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Box,
@@ -26,7 +26,7 @@ import {
   ContentCopy as DuplicateIcon,
   Edit as EditIcon,
 } from '@mui/icons-material'
-import { FixedSizeList } from 'react-window'
+import { List, type RowComponentProps } from 'react-window'
 import StatusChip from '../common/StatusChip'
 import GradientButton from '../common/GradientButton'
 import type { ArtifactSummary } from '../../types/authoring'
@@ -259,6 +259,109 @@ interface ArtifactVirtualListProps {
   tc: (key: string) => string
 }
 
+// react-window 2.x: row is a separate component receiving { index, style, ...rowProps }.
+// Spread rowProps carry the per-list data without re-rendering on every parent re-render
+// (List automatically memoizes them).
+type ArtifactRowProps = {
+  artifacts: ArtifactSummary[]
+  onSelect: (artifact: ArtifactSummary) => void
+  onDuplicate: (id: number) => void
+  onDelete: (id: number) => void
+  t: (key: string) => string
+  tc: (key: string) => string
+}
+
+function ArtifactRow({
+  index,
+  style,
+  artifacts,
+  onSelect,
+  onDuplicate,
+  onDelete,
+  t,
+  tc,
+}: RowComponentProps<ArtifactRowProps>) {
+  const artifact = artifacts[index]
+  // Row is a flex container matching the header table column widths.
+  // Wrapping each virtualized row in <Table> generated invalid HTML and
+  // forced a fresh layout root per row — flex avoids both.
+  return (
+    <Box
+      style={style}
+      onClick={() => onSelect(artifact)}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        cursor: 'pointer',
+        px: 2,
+        borderBottom: 1,
+        borderColor: 'divider',
+        '&:hover': { bgcolor: 'action.hover' },
+      }}
+    >
+      <Box sx={{ width: COL_WIDTHS.name, overflow: 'hidden', textOverflow: 'ellipsis', pr: 1 }}>
+        <Typography variant="body2" fontWeight={500} noWrap>
+          {artifact.name}
+        </Typography>
+        {artifact.description && (
+          <Typography variant="caption" color="text.secondary" noWrap sx={{ display: 'block' }}>
+            {artifact.description}
+          </Typography>
+        )}
+      </Box>
+      <Box sx={{ width: COL_WIDTHS.version }}>
+        <Typography variant="body2">{artifact.version}</Typography>
+      </Box>
+      <Box sx={{ width: COL_WIDTHS.status }}>
+        <StatusChip status={artifact.status} />
+      </Box>
+      <Box sx={{ width: COL_WIDTHS.updated }}>
+        <Typography variant="caption">
+          {new Date(artifact.updatedAt).toLocaleDateString()}
+        </Typography>
+      </Box>
+      <Box sx={{ width: COL_WIDTHS.actions }}>
+        <Stack direction="row" spacing={0} justifyContent="flex-end">
+          <Tooltip title={t('list.edit')}>
+            <IconButton
+              size="small"
+              onClick={(e) => {
+                e.stopPropagation()
+                onSelect(artifact)
+              }}
+            >
+              <EditIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title={t('list.duplicate')}>
+            <IconButton
+              size="small"
+              onClick={(e) => {
+                e.stopPropagation()
+                onDuplicate(artifact.id)
+              }}
+            >
+              <DuplicateIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title={tc('actions.delete')}>
+            <IconButton
+              size="small"
+              color="error"
+              onClick={(e) => {
+                e.stopPropagation()
+                onDelete(artifact.id)
+              }}
+            >
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Stack>
+      </Box>
+    </Box>
+  )
+}
+
 function ArtifactVirtualList({
   artifacts,
   onSelect,
@@ -267,101 +370,17 @@ function ArtifactVirtualList({
   t,
   tc,
 }: ArtifactVirtualListProps) {
-  const renderRow = useCallback(
-    ({ index, style }: { index: number; style: React.CSSProperties }) => {
-      const artifact = artifacts[index]
-      // Row is a flex container matching the header table column widths.
-      // Wrapping each virtualized row in <Table> generated invalid HTML and
-      // forced a fresh layout root per row — flex avoids both.
-      return (
-        <Box
-          key={artifact.id}
-          style={style}
-          onClick={() => onSelect(artifact)}
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            cursor: 'pointer',
-            px: 2,
-            borderBottom: 1,
-            borderColor: 'divider',
-            '&:hover': { bgcolor: 'action.hover' },
-          }}
-        >
-          <Box sx={{ width: COL_WIDTHS.name, overflow: 'hidden', textOverflow: 'ellipsis', pr: 1 }}>
-            <Typography variant="body2" fontWeight={500} noWrap>
-              {artifact.name}
-            </Typography>
-            {artifact.description && (
-              <Typography variant="caption" color="text.secondary" noWrap sx={{ display: 'block' }}>
-                {artifact.description}
-              </Typography>
-            )}
-          </Box>
-          <Box sx={{ width: COL_WIDTHS.version }}>
-            <Typography variant="body2">{artifact.version}</Typography>
-          </Box>
-          <Box sx={{ width: COL_WIDTHS.status }}>
-            <StatusChip status={artifact.status} />
-          </Box>
-          <Box sx={{ width: COL_WIDTHS.updated }}>
-            <Typography variant="caption">
-              {new Date(artifact.updatedAt).toLocaleDateString()}
-            </Typography>
-          </Box>
-          <Box sx={{ width: COL_WIDTHS.actions }}>
-            <Stack direction="row" spacing={0} justifyContent="flex-end">
-              <Tooltip title={t('list.edit')}>
-                <IconButton
-                  size="small"
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    onSelect(artifact)
-                  }}
-                >
-                  <EditIcon fontSize="small" />
-                </IconButton>
-              </Tooltip>
-              <Tooltip title={t('list.duplicate')}>
-                <IconButton
-                  size="small"
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    onDuplicate(artifact.id)
-                  }}
-                >
-                  <DuplicateIcon fontSize="small" />
-                </IconButton>
-              </Tooltip>
-              <Tooltip title={tc('actions.delete')}>
-                <IconButton
-                  size="small"
-                  color="error"
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    onDelete(artifact.id)
-                  }}
-                >
-                  <DeleteIcon fontSize="small" />
-                </IconButton>
-              </Tooltip>
-            </Stack>
-          </Box>
-        </Box>
-      )
-    },
-    [artifacts, onSelect, onDuplicate, onDelete, t, tc]
-  )
-
+  // react-window 2.x: List auto-sizes from its container, so we wrap it in a Box
+  // that enforces our explicit height (shrinks for short lists, caps at LIST_MAX_HEIGHT).
+  // overscanCount was removed in v2 in favor of a dynamic overscan strategy.
   return (
-    <FixedSizeList
-      height={Math.min(artifacts.length * ARTIFACT_ROW_HEIGHT, LIST_MAX_HEIGHT)}
-      width="100%"
-      itemCount={artifacts.length}
-      itemSize={ARTIFACT_ROW_HEIGHT}
-      overscanCount={5}
-    >
-      {renderRow}
-    </FixedSizeList>
+    <Box sx={{ height: Math.min(artifacts.length * ARTIFACT_ROW_HEIGHT, LIST_MAX_HEIGHT), width: '100%' }}>
+      <List
+        rowComponent={ArtifactRow}
+        rowCount={artifacts.length}
+        rowHeight={ARTIFACT_ROW_HEIGHT}
+        rowProps={{ artifacts, onSelect, onDuplicate, onDelete, t, tc }}
+      />
+    </Box>
   )
 }


### PR DESCRIPTION
## 變更說明

接手 dependabot #113 — react-window 1.8.11 → 2.2.7 升級。v2 拿掉 \`FixedSizeList\`，要把 \`ArtifactList.tsx\` migrate 到新 \`List\` API。

### API 差異

| Before (v1 \`FixedSizeList\`) | After (v2 \`List\`) |
|---|---|
| \`children={renderRow}\` (render prop) | \`rowComponent={Row}\` (component) |
| \`itemCount\` | \`rowCount\` |
| \`itemSize\` | \`rowHeight\` |
| \`height\` / \`width\` | auto-sized from parent container |
| \`overscanCount\` | (removed — dynamic) |
| Row signature \`({ index, style })\` | \`({ index, style, ...rowProps })\` via \`RowComponentProps<T>\` |

### 變更摘要

\`ArtifactList\` 是 codebase 內**唯一** \`react-window\` consumer。將原 inline \`renderRow\` \`useCallback\` 重構成 top-level \`ArtifactRow\` component；per-list data 透過 \`rowProps\` 傳遞（List 自動 memoize，不需 useCallback wrapping）。

為了保留 \`Math.min(n * rowHeight, LIST_MAX_HEIGHT)\` 動態高度（短列表縮、長列表 cap），用 \`<Box>\` 包住 \`<List>\` 設明確 height — v2 List 從父容器讀尺寸。

## 變更類型

- [x] 錯誤修復 (fix) — dependabot 升級配套 source migration
- [x] 重構 (refactor) — renderRow useCallback → 獨立 \`ArtifactRow\` component

## 關聯 Issue

Closes #113

## 測試紀錄

- [ ] 後端測試（不適用）
- [x] 前端測試 — CI 驗證 vitest + tsc + lint
- [x] 型別檢查（CI 驗證 \`npx tsc --noEmit\`）
- [ ] 手動測試 — 待 PR 上 merge 後在 VM 驗證 ArtifactList 渲染正常

## 風險評估

| 項目 | 說明 |
|------|------|
| 風險等級 | 低-中 |
| 影響範圍 | \`ArtifactList\` 元件渲染 — 視覺等效但內部 virtual scroll 實作換新 API |
| 回歸風險 | 低 — 唯一一個 consumer，無其他 \`FixedSizeList\` / \`VariableSizeList\` 用法 |

## 安全性確認

- [x] 此變更**不**涉及安全性等級 B/C 的功能（純前端 UI library 升級）
- [x] 已評估 OWASP Top 10 — 純 client-side rendering 改動
- [x] 無新硬編碼敏感資訊

🤖 Generated with [Claude Code](https://claude.com/claude-code)