### PR TITLE
fix(docker): bump Node heap to 4g for Vite build (Closes #529)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,7 +11,13 @@ RUN npm ci
 # Copy source
 COPY . .
 
-# Build the application
+# Build the application.
+# Bump Node heap to 4 GB: Vite bundling the Monaco-editor vendor chunk
+# (~3.7 MB raw / ~970 KB gzipped) plus the rest of the app pushes Rollup
+# past Node's default ~2 GB limit, causing FATAL ERROR Mark-Compact OOM on
+# CI runners and small VMs. 4 GB gives headroom while staying well under
+# typical runner / container limits.
+ENV NODE_OPTIONS=--max-old-space-size=4096
 RUN npm run build
 
 # Production stage


### PR DESCRIPTION
## Summary

- Vite + Rollup OOM during the BUG-117 hotfix rebuild on the production VM (`FATAL ERROR Mark-Compact near heap limit`)
- PR #529 had this exact fix but had drifted behind main — landing the 1-line `ENV NODE_OPTIONS=--max-old-space-size=4096` directly here to unblock deploy
- Closes #529

## Test plan

- [x] CI build green
- [ ] VM `docker compose build frontend` succeeds (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)