### PR TITLE
fix: move WS endpoint to /api/ws/notifications (path collision follow-up)

### DIFF
--- a/backend/src/main/java/com/cqlplatform/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/cqlplatform/config/WebSocketConfig.java
@@ -36,7 +36,14 @@ import java.util.Map;
 public class WebSocketConfig implements WebSocketConfigurer {
 
     public static final String USERNAME_ATTR = "username";
-    public static final String WS_PATH = "/api/notifications/ws";
+    // Path lives OUTSIDE /api/notifications/ on purpose: NotificationController
+    // has @DeleteMapping("/{id}") which Spring's MVC dispatcher matches against
+    // any single segment under /api/notifications/, returning 405 before the
+    // WebSocketHandlerMapping ever runs (MVC mapping has higher priority by
+    // Spring's autoconfig defaults). Putting the WS endpoint under a separate
+    // /api/ws/ namespace sidesteps the collision and makes the route
+    // self-documenting for future WS endpoints.
+    public static final String WS_PATH = "/api/ws/notifications";
 
     private final NotificationWebSocketHandler notificationHandler;
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -58,7 +58,9 @@ server {
     # `proxy_read_timeout 86400s` keeps the long-lived socket from being
     # cut by nginx itself; the backend sends protocol-level ping frames
     # every 25s so Cloudflare's WS idle timer (300s default) never expires.
-    location /api/notifications/ws {
+    # Path lives under /api/ws/ instead of /api/notifications/ to avoid
+    # collision with NotificationController's @DeleteMapping("/{id}").
+    location /api/ws/notifications {
         proxy_pass $backend_upstream$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/frontend/src/hooks/__tests__/useNotifications.test.tsx
+++ b/frontend/src/hooks/__tests__/useNotifications.test.tsx
@@ -91,7 +91,7 @@ describe('useNotifications — PAT-167 WebSocket lifecycle', () => {
     await vi.runAllTimersAsync()
     expect(api.post).toHaveBeenCalledWith('/auth/sse-ticket')
     expect(MockWebSocket.instances.length).toBe(1)
-    expect(MockWebSocket.instances[0].url).toContain('/api/notifications/ws')
+    expect(MockWebSocket.instances[0].url).toContain('/api/ws/notifications')
     expect(MockWebSocket.instances[0].url).toContain('ticket=ticket-1')
     expect(MockWebSocket.instances[0].url.startsWith('ws://') || MockWebSocket.instances[0].url.startsWith('wss://')).toBe(true)
   })

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -15,17 +15,20 @@ const UNREAD_COUNT_KEY = ['notifications', 'unread-count']
 // browsers auto-pong, so the entire `ERR_QUIC_PROTOCOL_ERROR / 524 Origin
 // Timeout` family of bugs is eliminated.
 
+// Path lives at /api/ws/notifications (not /api/notifications/ws) on purpose —
+// see WebSocketConfig.WS_PATH for why the WS route lives outside the controller
+// namespace.
 function buildWsUrl(ticket: string): string {
   const baseUrl = import.meta.env.VITE_API_URL || '/api'
   // Same-origin case: `/api`. Build absolute ws(s):// from window.location.
   if (baseUrl.startsWith('/')) {
     const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-    return `${proto}//${window.location.host}${baseUrl}/notifications/ws?ticket=${encodeURIComponent(ticket)}`
+    return `${proto}//${window.location.host}${baseUrl}/ws/notifications?ticket=${encodeURIComponent(ticket)}`
   }
   // Absolute URL configured (rare): swap http(s):// → ws(s)://
   const proto = baseUrl.startsWith('https') ? 'wss' : 'ws'
   const rest = baseUrl.replace(/^https?/, '')
-  return `${proto}${rest}/notifications/ws?ticket=${encodeURIComponent(ticket)}`
+  return `${proto}${rest}/ws/notifications?ticket=${encodeURIComponent(ticket)}`
 }
 
 export function useNotifications() {


### PR DESCRIPTION
## Summary

Follow-up to #545. During VM E2E verification the WS handshake came back as HTTP 500 (Spring mapped `HttpRequestMethodNotSupportedException` through `GlobalExceptionHandler`) instead of 101 Switching Protocols.

Root cause: `NotificationController` has `@DeleteMapping(\"/{id}\")` which Spring's MVC dispatcher matches against any single segment under `/api/notifications/` (including `ws`). MVC handler mapping has higher priority by Spring autoconfig defaults than `WebSocketHandlerMapping`, so the WS request never reached the upgrade handler.

Fix: move the WS endpoint to `/api/ws/notifications` (separate prefix outside the controller namespace).

## Test plan

- [x] Lint + tests updated for new URL
- [ ] CI green
- [ ] VM E2E: WS handshake returns 101 + receives initial unread-count text frame + ≥1 protocol ping within 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)