### PR TITLE
fix: allow any Origin on /api/ws/notifications (Cloudflare/nginx forwarding)

### DIFF
--- a/backend/src/main/java/com/cqlplatform/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/cqlplatform/config/WebSocketConfig.java
@@ -54,7 +54,16 @@ public class WebSocketConfig implements WebSocketConfigurer {
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
         registry.addHandler(notificationHandler, WS_PATH)
-                .addInterceptors(new TicketHandshakeInterceptor());
+                .addInterceptors(new TicketHandshakeInterceptor())
+                // Spring's default OriginHandshakeInterceptor rejects any
+                // upgrade whose Origin header doesn't match the request's
+                // host:port. Behind the nginx reverse proxy that pretty much
+                // always rejects (backend sees Host=backend:8080, Origin=
+                // https://www.twcql.com), so allow any origin pattern here —
+                // auth is bound to a single-use ticket redeemed before this
+                // interceptor runs, so the Origin check would only be a defense
+                // against CSRF, which a single-use ticket already mitigates.
+                .setAllowedOriginPatterns("*");
     }
 
     static class TicketHandshakeInterceptor implements HandshakeInterceptor {


### PR DESCRIPTION
## Summary

Follow-up to #545 / #546. VM E2E confirmed handshake returns 403 through nginx but 101 Switching Protocols direct-to-backend.

Root cause: Spring's `OriginHandshakeInterceptor` rejects any upgrade whose Origin doesn't match the request host:port. Behind the nginx reverse proxy, the backend sees `Host=backend:8080` (internal Docker name) but `Origin=https://www.twcql.com` (or `localhost:8888` in tests) — perpetual mismatch.

Fix: `setAllowedOriginPatterns(\"*\")`. CSRF defense intact: the handshake is gated on a single-use ticket from `SseTicketService` (one-shot, 30s TTL).

## Test plan

- [x] CI green
- [ ] VM E2E: WS handshake through nginx → 101 + initial unread-count text frame + ≥1 ping in 30s